### PR TITLE
Index addresses of validator events

### DIFF
--- a/contracts/upgradeable_contracts/U_BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/U_BridgeValidators.sol
@@ -8,8 +8,8 @@ import "../upgradeability/EternalStorage.sol";
 
 contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
     using SafeMath for uint256;
-    event ValidatorAdded (address validator);
-    event ValidatorRemoved (address validator);
+    event ValidatorAdded (address indexed validator);
+    event ValidatorRemoved (address indexed validator);
     event RequiredSignaturesChanged (uint256 requiredSignatures);
 
     function initialize(uint256 _requiredSignatures, address[] _initialValidators, address _owner)


### PR DESCRIPTION
See [this discussion](https://github.com/poanetwork/bridge-nodejs/issues/7) for why this is necessary.

Adding the index to the `ValidationRemoved` is not technically necessary now, but I added it for consistency.