### PR TITLE
add feature on token transfer invoke contractFallback silently

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "flatten": "bash flatten.sh",
     "watch-tests": "./node_modules/.bin/nodemon ./node_modules/.bin/truffle test --network test"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "POA network",
+  "license": "GPLv3",
   "dependencies": {
     "ganache-cli": "^6.1.0",
     "openzeppelin-solidity": "^1.10.0",

--- a/test/testContracts/ERC677ReceiverTest.sol
+++ b/test/testContracts/ERC677ReceiverTest.sol
@@ -9,11 +9,11 @@ contract ERC677ReceiverTest is ERC677Receiver {
     bytes public data;
     uint public someVar = 0;
 
-    function onTokenTransfer(address _from, uint _value, bytes _data) external returns(bool) {
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns(bool) {
         from = _from;
         value = _value;
         data = _data;
-        require(address(this).call(_data));
+        address(this).call(_data);
         return true;
     }
 


### PR DESCRIPTION
1. Change `transfer` method to invoke `onTokenTransfer` if recipient is contract