### PR TITLE
Prevent an attack to send cross chain transfer using contract without payable fallback

### DIFF
--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -5,6 +5,12 @@ import "../BasicBridge.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../BasicHomeBridge.sol";
 
+contract Sacrifice {
+    constructor(address _recipient) public payable {
+        selfdestruct(_recipient);
+    }
+}
+
 contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
 
     function initialize (
@@ -42,7 +48,9 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value) internal returns(bool) {
-        _recipient.transfer(_value);
+        if (!_recipient.send(_value)) {
+            (new Sacrifice).value(_value)(_recipient);
+        }
         return true;
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "flatten": "bash flatten.sh",
     "watch-tests": "./node_modules/.bin/nodemon ./node_modules/.bin/truffle test --network test"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "POA network",
+  "license": "GPLv3",
   "dependencies": {
     "ganache-cli": "^6.1.0",
     "openzeppelin-solidity": "^1.10.0",

--- a/test/testContracts/ERC677ReceiverTest.sol
+++ b/test/testContracts/ERC677ReceiverTest.sol
@@ -9,11 +9,11 @@ contract ERC677ReceiverTest is ERC677Receiver {
     bytes public data;
     uint public someVar = 0;
 
-    function onTokenTransfer(address _from, uint _value, bytes _data) external returns(bool) {
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns(bool) {
         from = _from;
         value = _value;
         data = _data;
-        require(address(this).call(_data));
+        address(this).call(_data);
         return true;
     }
 

--- a/test/testContracts/RevertFallback.sol
+++ b/test/testContracts/RevertFallback.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.4.24;
+
+
+contract RevertFallback {
+    function () public payable {
+        revert();
+    }
+
+    function receiveEth() public payable {
+
+    }
+}


### PR DESCRIPTION
this PR depends on #50 

Scenario:

1. Deploy a contract with `revert` in `fallback` on both chains: Home and Foreign
2. Use a bridge to initiate a transfer
3. Make sure the bridge still is able to send funds to recipient using self-destructed contract.