### PR TITLE
Add deployedAtBlock on BridgeValidators

### DIFF
--- a/contracts/upgradeable_contracts/U_BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/U_BridgeValidators.sol
@@ -30,7 +30,7 @@ contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
         require(validatorCount() >= _requiredSignatures);
         uintStorage[keccak256("requiredSignatures")] = _requiredSignatures;
         uintStorage[keccak256("deployedAtBlock")] = block.number;
-    setInitialize(true);
+        setInitialize(true);
         return isInitialized();
     }
 

--- a/contracts/upgradeable_contracts/U_BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/U_BridgeValidators.sol
@@ -29,7 +29,8 @@ contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
         }
         require(validatorCount() >= _requiredSignatures);
         uintStorage[keccak256("requiredSignatures")] = _requiredSignatures;
-        setInitialize(true);
+        uintStorage[keccak256("deployedAtBlock")] = block.number;
+    setInitialize(true);
         return isInitialized();
     }
 
@@ -74,6 +75,10 @@ contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
 
     function isInitialized() public view returns(bool) {
         return boolStorage[keccak256("isInitialized")];
+    }
+
+    function deployedAtBlock() public view returns(uint256) {
+        return uintStorage[keccak256("deployedAtBlock")];
     }
 
     function setValidatorCount(uint256 _validatorCount) private {

--- a/test/validators_test.js
+++ b/test/validators_test.js
@@ -18,6 +18,7 @@ contract('BridgeValidators', async (accounts) => {
       false.should.be.equal(await bridgeValidators.isValidator(accounts[1]))
       false.should.be.equal(await bridgeValidators.isInitialized())
       '0'.should.be.bignumber.equal(await bridgeValidators.requiredSignatures())
+      '0'.should.be.bignumber.equal(await bridgeValidators.deployedAtBlock())
       await bridgeValidators.initialize(3, [accounts[0], accounts[1]], accounts[2], {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG)
       await bridgeValidators.initialize(2, [accounts[0], accounts[1]], accounts[2], {from: accounts[2]}).should.be.fulfilled;
       await bridgeValidators.initialize(2, [accounts[0], accounts[1]], accounts[2], {from: accounts[2]}).should.be.rejectedWith(ERROR_MSG);
@@ -26,7 +27,8 @@ contract('BridgeValidators', async (accounts) => {
       true.should.be.equal(await bridgeValidators.isValidator(accounts[0]))
       true.should.be.equal(await bridgeValidators.isValidator(accounts[1]))
       accounts[2].should.be.equal(await bridgeValidators.owner())
-      '2'.should.be.bignumber.equal(await bridgeValidators.validatorCount())
+      '2'.should.be.bignumber.equal(await bridgeValidators.validatorCount());
+      (await bridgeValidators.deployedAtBlock()).should.be.bignumber.above(0)
     })
   })
 


### PR DESCRIPTION
Adds `deployedAtBlock` function on BridgeValidators contract so we can know from which block start listening to events on the contract. See [this comment](https://github.com/poanetwork/bridge-nodejs/pull/47#discussion_r202377070)