### PR TITLE
Avoid missing directory error on flatten.sh

### DIFF
--- a/flatten.sh
+++ b/flatten.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ ! -d "flats" ]; then
+	mkdir flats
+fi
+
 rm -rf flats/*
 ./node_modules/.bin/truffle-flattener contracts/upgradeable_contracts/U_ForeignBridge.sol > flats/ForeignBridge_flat.sol
 ./node_modules/.bin/truffle-flattener contracts/upgradeable_contracts/U_BridgeValidators.sol > flats/BridgeValidators_flat.sol

--- a/flatten.sh
+++ b/flatten.sh
@@ -2,9 +2,10 @@
 
 if [ ! -d "flats" ]; then
 	mkdir flats
+else
+	rm -rf flats/*
 fi
 
-rm -rf flats/*
 ./node_modules/.bin/truffle-flattener contracts/upgradeable_contracts/U_ForeignBridge.sol > flats/ForeignBridge_flat.sol
 ./node_modules/.bin/truffle-flattener contracts/upgradeable_contracts/U_BridgeValidators.sol > flats/BridgeValidators_flat.sol
 ./node_modules/.bin/truffle-flattener contracts/upgradeable_contracts/U_HomeBridge.sol > flats/HomeBridge_flat.sol


### PR DESCRIPTION
Added directory presence check to avoid error on script call. If the directory doesn't exist, create it.
(can be propagated to all branches)