### PR TITLE
Add requiredMessageLength method to BasicHomeBridge contract

### DIFF
--- a/contracts/libraries/Message.sol
+++ b/contracts/libraries/Message.sol
@@ -66,7 +66,7 @@ library Message {
         return _msg.length == requiredMessageLength();
     }
 
-    function requiredMessageLength() public pure returns(uint256) {
+    function requiredMessageLength() internal pure returns(uint256) {
         return 104;
     }
 

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -141,5 +141,7 @@ contract BasicHomeBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("numMessagesSigned", _message))];
     }
 
-
+    function requiredMessageLength() public pure returns(uint256) {
+        return Message.requiredMessageLength();
+    }
 }

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -324,4 +324,15 @@ contract('HomeBridge_ERC20_to_ERC20', async (accounts) => {
       logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesTwoAccs[1])
     })
   })
+
+  describe('#requiredMessageLength', async () => {
+    beforeEach(async () => {
+      homeContract = await HomeBridge.new()
+    })
+
+    it('should return the required message length', async () => {
+      const requiredMessageLength = await homeContract.requiredMessageLength()
+      '104'.should.be.bignumber.equal(requiredMessageLength)
+    })
+  })
 })

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -411,4 +411,15 @@ contract('HomeBridge', async (accounts) => {
       logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesTwoAccs[1])
     })
   })
+
+  describe('#requiredMessageLength', async () => {
+    beforeEach(async () => {
+      homeContract = await HomeBridge.new()
+    })
+
+    it('should return the required message length', async () => {
+      const requiredMessageLength = await homeContract.requiredMessageLength()
+      '104'.should.be.bignumber.equal(requiredMessageLength)
+    })
+  })
 })


### PR DESCRIPTION
This is necessary for https://github.com/poanetwork/bridge-nodejs/issues/56.

I also modified the library method to `internal` so that it's inlined in the bridge contract method. This is necessary because the deploy script is not deploying and linking the `Message` library, so using non-internal methods causes the deploy to fail.