### PR TITLE
Allow using the deploy script from another directory

### DIFF
--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -1,5 +1,8 @@
 const fs = require('fs');
-require('dotenv').config();
+const path = require('path')
+require('dotenv').config({
+  path: path.join(__dirname, '.env')
+});
 
 async function deployNativeToErc(){
   const deployHome = require('./src/native_to_erc/home');
@@ -11,7 +14,8 @@ async function deployNativeToErc(){
   console.log(`[   Home  ] HomeBridge: ${homeBridge.address} at block ${homeBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] ForeignBridge: ${foreignBridge.address} at block ${foreignBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] POA20: ${erc677.address}`)
-  fs.writeFileSync('./bridgeDeploymentResults.json', JSON.stringify({
+  const deployResultsPath = path.join(__dirname, './bridgeDeploymentResults.json')
+  fs.writeFileSync(deployResultsPath, JSON.stringify({
     homeBridge: {
       ...homeBridge,
     },foreignBridge: {

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -4,6 +4,8 @@ require('dotenv').config({
   path: path.join(__dirname, '.env')
 });
 
+const deployResultsPath = path.join(__dirname, './bridgeDeploymentResults.json')
+
 async function deployNativeToErc(){
   const deployHome = require('./src/native_to_erc/home');
   const deployForeign = require('./src/native_to_erc/foreign');
@@ -14,7 +16,6 @@ async function deployNativeToErc(){
   console.log(`[   Home  ] HomeBridge: ${homeBridge.address} at block ${homeBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] ForeignBridge: ${foreignBridge.address} at block ${foreignBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] POA20: ${erc677.address}`)
-  const deployResultsPath = path.join(__dirname, './bridgeDeploymentResults.json')
   fs.writeFileSync(deployResultsPath, JSON.stringify({
     homeBridge: {
       ...homeBridge,
@@ -36,7 +37,7 @@ async function deployErcToErc() {
   console.log(`[ Foreign ] ForeignBridge: ${foreignBridge.address} at block ${foreignBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] ERC20 Token: ${process.env.ERC20_TOKEN_ADDRESS}`)
   console.log(`[ Home ] ERC677 Bridgeble Token: ${erc677tokenAddress}`)
-  fs.writeFileSync('./bridgeDeploymentResults.json', JSON.stringify({
+  fs.writeFileSync(deployResultsPath, JSON.stringify({
     homeBridge: {
       homeBridgeAddress,
       erc677tokenAddress


### PR DESCRIPTION
When working on the bridge, I often do this:

```
cd submodules/poa-bridge-contracts/deploy
node deploy.js
cd -
```

when I could do:

```
node submodules/poa-bridge-contracts/deploy/deploy.js
```

Even better: we could have a npm script that deploys the contracts. Right now this isn't possible because the deploy script uses paths relative to the cwd of the process. This PR makes these paths independent.