### PR TITLE
Avoid missing directory error on flatten

### DIFF
--- a/flatten.sh
+++ b/flatten.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-rm -rf flats/*
+if [ ! -d "flats" ]; then
+	mkdir flats
+else
+	rm -rf flats/*
+fi
+
 mkdir -p flats/native_to_erc20
 mkdir -p flats/erc20_to_erc20
 


### PR DESCRIPTION
Added a directory check before any updates in the flats folder. This avoid errors on the first time the script is used.