### PR TITLE
Add bridge mode field and interfaces version support

### DIFF
--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -14,7 +14,7 @@ contract ERC677BridgeToken is
     BurnableToken,
     MintableToken {
 
-    Version.Version public getTokenInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getTokenInterfacesVersion = Version.Version(2, 0, 0);
 
     constructor(
         string _name,

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -14,7 +14,7 @@ contract ERC677BridgeToken is
     BurnableToken,
     MintableToken {
 
-    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getTokenInterfacesVersion = Version.Version(1, 0, 0);
 
     constructor(
         string _name,

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -14,7 +14,7 @@ contract ERC677BridgeToken is
     BurnableToken,
     MintableToken {
 
-    Version.Version public getInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
 
     constructor(
         string _name,

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -5,6 +5,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import "./IBurnableMintableERC677Token.sol";
 import "./ERC677Receiver.sol";
+import "./libraries/Version.sol";
 
 
 contract ERC677BridgeToken is
@@ -12,6 +13,9 @@ contract ERC677BridgeToken is
     DetailedERC20,
     BurnableToken,
     MintableToken {
+
+    Version.Version public getInterfacesVersion = Version.Version(1, 0, 0);
+
     constructor(
         string _name,
         string _symbol,

--- a/contracts/libraries/Version.sol
+++ b/contracts/libraries/Version.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.4.24;
+
+
+library Version {
+
+    struct Version {
+        uint64 major;
+        uint64 minor;
+        uint64 patch;
+    }
+
+}

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -16,14 +16,6 @@ contract BasicBridge is EternalStorage, Validatable {
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
     event DailyLimitChanged(uint256 newLimit);
 
-    function bridgeMode() public view returns(bytes) {
-        return bytesStorage[keccak256(abi.encodePacked("bridgeMode"))];
-    }
-
-    function setBridgeMode(bytes _mode) internal {
-        bytesStorage[keccak256(abi.encodePacked("bridgeMode"))] = _mode;
-    }
-
     function setGasPrice(uint256 _gasPrice) public onlyOwner {
         require(_gasPrice > 0);
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -12,6 +12,14 @@ contract BasicBridge is EternalStorage, Validatable {
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
     event DailyLimitChanged(uint256 newLimit);
 
+    function bridgeMode() public view returns(bytes) {
+        return bytesStorage[keccak256(abi.encodePacked("bridgeMode"))];
+    }
+
+    function setBridgeMode(bytes _mode) internal {
+        bytesStorage[keccak256(abi.encodePacked("bridgeMode"))] = _mode;
+    }
+
     function setGasPrice(uint256 _gasPrice) public onlyOwner {
         require(_gasPrice > 0);
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -10,7 +10,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 contract BasicBridge is EternalStorage, Validatable {
     using SafeMath for uint256;
 
-    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getBridgeInterfacesVersion = Version.Version(2, 0, 0);
 
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -2,12 +2,16 @@ pragma solidity 0.4.24;
 import "../IBridgeValidators.sol";
 import "../upgradeability/EternalStorage.sol";
 import "../libraries/SafeMath.sol";
+import "../libraries/Version.sol";
 import "./Validatable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
 
 contract BasicBridge is EternalStorage, Validatable {
     using SafeMath for uint256;
+
+    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
+
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
     event DailyLimitChanged(uint256 newLimit);

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -4,10 +4,14 @@ import "./Ownable.sol";
 import "../IBridgeValidators.sol";
 import "../libraries/SafeMath.sol";
 import "../upgradeability/EternalStorage.sol";
+import "../libraries/Version.sol";
 
 
 contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
     using SafeMath for uint256;
+
+    Version.Version public getInterfacesVersion = Version.Version(1, 0, 0);
+
     event ValidatorAdded (address indexed validator);
     event ValidatorRemoved (address indexed validator);
     event RequiredSignaturesChanged (uint256 requiredSignatures);

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -10,7 +10,7 @@ import "../libraries/Version.sol";
 contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
     using SafeMath for uint256;
 
-    Version.Version public getBridgeValidatorsInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getBridgeValidatorsInterfacesVersion = Version.Version(2, 0, 0);
 
     event ValidatorAdded (address indexed validator);
     event ValidatorRemoved (address indexed validator);

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -10,7 +10,7 @@ import "../libraries/Version.sol";
 contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
     using SafeMath for uint256;
 
-    Version.Version public getInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
 
     event ValidatorAdded (address indexed validator);
     event ValidatorRemoved (address indexed validator);

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -10,7 +10,7 @@ import "../libraries/Version.sol";
 contract BridgeValidators is IBridgeValidators, EternalStorage, Ownable {
     using SafeMath for uint256;
 
-    Version.Version public getBridgeInterfacesVersion = Version.Version(1, 0, 0);
+    Version.Version public getBridgeValidatorsInterfacesVersion = Version.Version(1, 0, 0);
 
     event ValidatorAdded (address indexed validator);
     event ValidatorRemoved (address indexed validator);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -10,8 +10,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
 contract ForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
 
-    bytes internal constant BRIDGE_MODE = hex"ba4690f5"; // 4 bytes of keccak256('erc-to-erc-core')
-
     event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
 
     function initialize(
@@ -26,9 +24,12 @@ contract ForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
+    }
+
+    function getBridgeMode() public pure returns(bytes4 _data) {
+        return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 
     function claimTokens(address _token, address _to) public onlyOwner {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -9,6 +9,9 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
 
 contract ForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
+
+    bytes internal constant BRIDGE_MODE = hex"ba4690f5"; // 4 bytes of keccak256('erc-to-erc-core')
+
     event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
 
     function initialize(
@@ -23,6 +26,7 @@ contract ForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -37,11 +37,14 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         setErc677token(_erc677token);
 
         return isInitialized();
+    }
+
+    function getBridgeMode() public pure returns(bytes4 _data) {
+        return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 
     function () public {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -11,8 +11,6 @@ import "../ERC677Bridge.sol";
 
 contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, BasicHomeBridge, ERC677Bridge {
 
-    bytes internal constant BRIDGE_MODE = hex"ba4690f5"; // 4 bytes of keccak256('erc-to-erc-core')
-
     function initialize (
         address _validatorContract,
         uint256 _dailyLimit,

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -11,6 +11,8 @@ import "../ERC677Bridge.sol";
 
 contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, BasicHomeBridge, ERC677Bridge {
 
+    bytes internal constant BRIDGE_MODE = hex"ba4690f5"; // 4 bytes of keccak256('erc-to-erc-core')
+
     function initialize (
         address _validatorContract,
         uint256 _dailyLimit,
@@ -35,6 +37,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         setErc677token(_erc677token);
 

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -9,6 +9,9 @@ import "../ERC677Bridge.sol";
 
 
 contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBridge, ERC677Bridge {
+
+    bytes internal constant BRIDGE_MODE = hex"92a8d7fe"; // 4 bytes of keccak256('native-to-erc-core')
+
     /// Event created on money withdraw.
     event UserRequestForAffirmation(address recipient, uint256 value);
 
@@ -33,6 +36,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _foreignGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -10,8 +10,6 @@ import "../ERC677Bridge.sol";
 
 contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBridge, ERC677Bridge {
 
-    bytes internal constant BRIDGE_MODE = hex"92a8d7fe"; // 4 bytes of keccak256('native-to-erc-core')
-
     /// Event created on money withdraw.
     event UserRequestForAffirmation(address recipient, uint256 value);
 
@@ -36,9 +34,12 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _foreignGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
+    }
+
+    function getBridgeMode() public pure returns(bytes4 _data) {
+        return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 
     function claimTokensFromErc677(address _token, address _to) external onlyOwner {

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -13,8 +13,6 @@ contract Sacrifice {
 
 contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
 
-    bytes internal constant BRIDGE_MODE = hex"92a8d7fe"; // 4 bytes of keccak256('native-to-erc-core')
-
     function initialize (
         address _validatorContract,
         uint256 _dailyLimit,
@@ -37,7 +35,6 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
     }
@@ -48,6 +45,10 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
         require(withinLimit(msg.value));
         setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(msg.value));
         emit UserRequestForSignature(msg.sender, msg.value);
+    }
+
+    function getBridgeMode() public pure returns(bytes4 _data) {
+        return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value) internal returns(bool) {

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -13,6 +13,8 @@ contract Sacrifice {
 
 contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
 
+    bytes internal constant BRIDGE_MODE = hex"92a8d7fe"; // 4 bytes of keccak256('native-to-erc-core')
+
     function initialize (
         address _validatorContract,
         uint256 _dailyLimit,
@@ -35,6 +37,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge {
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        setBridgeMode(BRIDGE_MODE);
         setInitialize(true);
         return isInitialized();
     }

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -39,6 +39,10 @@ contract('ForeignBridge_ERC20_to_ERC20', async (accounts) => {
       const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
       const mode = await foreignBridge.bridgeMode();
       mode.should.be.equal(bridgeMode)
+      const [major, minor, patch] = await foreignBridge.getBridgeInterfacesVersion()
+      major.should.be.bignumber.gte(0)
+      minor.should.be.bignumber.gte(0)
+      patch.should.be.bignumber.gte(0)
     })
   })
   describe('#executeSignatures', async () => {

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -36,6 +36,9 @@ contract('ForeignBridge_ERC20_to_ERC20', async (accounts) => {
       token.address.should.be.equal(await foreignBridge.erc20token());
       (await foreignBridge.deployedAtBlock()).should.be.bignumber.above(0);
       requireBlockConfirmations.should.be.bignumber.equal(await foreignBridge.requiredBlockConfirmations())
+      const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
+      const mode = await foreignBridge.bridgeMode();
+      mode.should.be.equal(bridgeMode)
     })
   })
   describe('#executeSignatures', async () => {

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -37,7 +37,7 @@ contract('ForeignBridge_ERC20_to_ERC20', async (accounts) => {
       (await foreignBridge.deployedAtBlock()).should.be.bignumber.above(0);
       requireBlockConfirmations.should.be.bignumber.equal(await foreignBridge.requiredBlockConfirmations())
       const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
-      const mode = await foreignBridge.bridgeMode();
+      const mode = await foreignBridge.getBridgeMode();
       mode.should.be.equal(bridgeMode)
       const [major, minor, patch] = await foreignBridge.getBridgeInterfacesVersion()
       major.should.be.bignumber.gte(0)

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -38,6 +38,9 @@ contract('HomeBridge_ERC20_to_ERC20', async (accounts) => {
       '3'.should.be.bignumber.equal(await homeContract.dailyLimit())
       '2'.should.be.bignumber.equal(await homeContract.maxPerTx())
       '1'.should.be.bignumber.equal(await homeContract.minPerTx())
+      const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
+      const mode = await homeContract.bridgeMode();
+      mode.should.be.equal(bridgeMode)
     })
     it('cant set maxPerTx > dailyLimit', async () => {
       false.should.be.equal(await homeContract.isInitialized())

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -39,7 +39,7 @@ contract('HomeBridge_ERC20_to_ERC20', async (accounts) => {
       '2'.should.be.bignumber.equal(await homeContract.maxPerTx())
       '1'.should.be.bignumber.equal(await homeContract.minPerTx())
       const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
-      const mode = await homeContract.bridgeMode();
+      const mode = await homeContract.getBridgeMode();
       mode.should.be.equal(bridgeMode)
       const [major, minor, patch] = await homeContract.getBridgeInterfacesVersion()
       major.should.be.bignumber.gte(0)

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -41,6 +41,10 @@ contract('HomeBridge_ERC20_to_ERC20', async (accounts) => {
       const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
       const mode = await homeContract.bridgeMode();
       mode.should.be.equal(bridgeMode)
+      const [major, minor, patch] = await homeContract.getBridgeInterfacesVersion()
+      major.should.be.bignumber.gte(0)
+      minor.should.be.bignumber.gte(0)
+      patch.should.be.bignumber.gte(0)
     })
     it('cant set maxPerTx > dailyLimit', async () => {
       false.should.be.equal(await homeContract.isInitialized())

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -57,6 +57,10 @@ contract('ForeignBridge', async (accounts) => {
       const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
       const mode = await foreignBridge.bridgeMode();
       mode.should.be.equal(bridgeMode)
+      const [major, minor, patch] = await foreignBridge.getBridgeInterfacesVersion()
+      major.should.be.bignumber.gte(0)
+      minor.should.be.bignumber.gte(0)
+      patch.should.be.bignumber.gte(0)
     })
   })
   describe('#executeSignatures', async () => {

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -54,6 +54,9 @@ contract('ForeignBridge', async (accounts) => {
       oneEther.should.be.bignumber.equal(await foreignBridge.dailyLimit())
       halfEther.should.be.bignumber.equal(await foreignBridge.maxPerTx())
       minPerTx.should.be.bignumber.equal(await foreignBridge.minPerTx())
+      const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
+      const mode = await foreignBridge.bridgeMode();
+      mode.should.be.equal(bridgeMode)
     })
   })
   describe('#executeSignatures', async () => {

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -55,7 +55,7 @@ contract('ForeignBridge', async (accounts) => {
       halfEther.should.be.bignumber.equal(await foreignBridge.maxPerTx())
       minPerTx.should.be.bignumber.equal(await foreignBridge.minPerTx())
       const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
-      const mode = await foreignBridge.bridgeMode();
+      const mode = await foreignBridge.getBridgeMode();
       mode.should.be.equal(bridgeMode)
       const [major, minor, patch] = await foreignBridge.getBridgeInterfacesVersion()
       major.should.be.bignumber.gte(0)

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -36,6 +36,9 @@ contract('HomeBridge', async (accounts) => {
       '3'.should.be.bignumber.equal(await homeContract.dailyLimit())
       '2'.should.be.bignumber.equal(await homeContract.maxPerTx())
       '1'.should.be.bignumber.equal(await homeContract.minPerTx())
+      const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
+      const mode = await homeContract.bridgeMode();
+      mode.should.be.equal(bridgeMode)
     })
     it('cant set maxPerTx > dailyLimit', async () => {
       false.should.be.equal(await homeContract.isInitialized())

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -39,6 +39,10 @@ contract('HomeBridge', async (accounts) => {
       const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
       const mode = await homeContract.bridgeMode();
       mode.should.be.equal(bridgeMode)
+      const [major, minor, patch] = await homeContract.getBridgeInterfacesVersion()
+      major.should.be.bignumber.gte(0)
+      minor.should.be.bignumber.gte(0)
+      patch.should.be.bignumber.gte(0)
     })
     it('cant set maxPerTx > dailyLimit', async () => {
       false.should.be.equal(await homeContract.isInitialized())

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -37,7 +37,7 @@ contract('HomeBridge', async (accounts) => {
       '2'.should.be.bignumber.equal(await homeContract.maxPerTx())
       '1'.should.be.bignumber.equal(await homeContract.minPerTx())
       const bridgeMode = '0x92a8d7fe' // 4 bytes of keccak256('native-to-erc-core')
-      const mode = await homeContract.bridgeMode();
+      const mode = await homeContract.getBridgeMode();
       mode.should.be.equal(bridgeMode)
       const [major, minor, patch] = await homeContract.getBridgeInterfacesVersion()
       major.should.be.bignumber.gte(0)

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -26,7 +26,7 @@ contract('ERC677BridgeToken', async (accounts) => {
     const mintingFinished = await token.mintingFinished();
     assert.equal(mintingFinished, false);
 
-    const [major, minor, patch] = await token.getInterfacesVersion()
+    const [major, minor, patch] = await token.getBridgeInterfacesVersion()
     major.should.be.bignumber.gte(0)
     minor.should.be.bignumber.gte(0)
     patch.should.be.bignumber.gte(0)

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -26,6 +26,10 @@ contract('ERC677BridgeToken', async (accounts) => {
     const mintingFinished = await token.mintingFinished();
     assert.equal(mintingFinished, false);
 
+    const [major, minor, patch] = await token.getInterfacesVersion()
+    major.should.be.bignumber.gte(0)
+    minor.should.be.bignumber.gte(0)
+    patch.should.be.bignumber.gte(0)
   })
   describe('#mint', async() => {
     it('can mint by owner', async () => {

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -26,7 +26,7 @@ contract('ERC677BridgeToken', async (accounts) => {
     const mintingFinished = await token.mintingFinished();
     assert.equal(mintingFinished, false);
 
-    const [major, minor, patch] = await token.getBridgeInterfacesVersion()
+    const [major, minor, patch] = await token.getTokenInterfacesVersion()
     major.should.be.bignumber.gte(0)
     minor.should.be.bignumber.gte(0)
     patch.should.be.bignumber.gte(0)

--- a/test/validators_test.js
+++ b/test/validators_test.js
@@ -29,7 +29,7 @@ contract('BridgeValidators', async (accounts) => {
       accounts[2].should.be.equal(await bridgeValidators.owner())
       '2'.should.be.bignumber.equal(await bridgeValidators.validatorCount());
       (await bridgeValidators.deployedAtBlock()).should.be.bignumber.above(0)
-      const [major, minor, patch] = await bridgeValidators.getBridgeInterfacesVersion()
+      const [major, minor, patch] = await bridgeValidators.getBridgeValidatorsInterfacesVersion()
       major.should.be.bignumber.gte(0)
       minor.should.be.bignumber.gte(0)
       patch.should.be.bignumber.gte(0)

--- a/test/validators_test.js
+++ b/test/validators_test.js
@@ -29,7 +29,7 @@ contract('BridgeValidators', async (accounts) => {
       accounts[2].should.be.equal(await bridgeValidators.owner())
       '2'.should.be.bignumber.equal(await bridgeValidators.validatorCount());
       (await bridgeValidators.deployedAtBlock()).should.be.bignumber.above(0)
-      const [major, minor, patch] = await bridgeValidators.getInterfacesVersion()
+      const [major, minor, patch] = await bridgeValidators.getBridgeInterfacesVersion()
       major.should.be.bignumber.gte(0)
       minor.should.be.bignumber.gte(0)
       patch.should.be.bignumber.gte(0)

--- a/test/validators_test.js
+++ b/test/validators_test.js
@@ -29,6 +29,10 @@ contract('BridgeValidators', async (accounts) => {
       accounts[2].should.be.equal(await bridgeValidators.owner())
       '2'.should.be.bignumber.equal(await bridgeValidators.validatorCount());
       (await bridgeValidators.deployedAtBlock()).should.be.bignumber.above(0)
+      const [major, minor, patch] = await bridgeValidators.getInterfacesVersion()
+      major.should.be.bignumber.gte(0)
+      minor.should.be.bignumber.gte(0)
+      patch.should.be.bignumber.gte(0)
     })
   })
 


### PR DESCRIPTION
Closes #67 

Add `getBridgeMode` method on bridge contracts and add `getBridgeInterfacesVersion`  method on bridge, ERC677 token  and validators contract.