### PR TITLE
Extend limits functionality

### DIFF
--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -125,14 +125,6 @@ contract BasicBridge is EternalStorage, Validatable {
         return oppositeSideDailyLimit() >= nextLimit && _amount <= oppositeSideMaxPerTx();
     }
 
-    function outOfLimitAmount() public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
-    }
-
-    function setOutOfLimitAmount(uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
-    }
-
     function claimTokens(address _token, address _to) public onlyOwner {
         require(_to != address(0));
         if (_token == address(0)) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -15,7 +15,7 @@ contract BasicBridge is EternalStorage, Validatable {
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
     function getBridgeInterfacesVersion() public pure returns(uint64 major, uint64 minor, uint64 patch) {
-        return (2, 1, 0);
+        return (2, 2, 0);
     }
 
     function setGasPrice(uint256 _gasPrice) public onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -12,7 +12,7 @@ contract BasicBridge is EternalStorage, Validatable {
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
     event DailyLimitChanged(uint256 newLimit);
-    event OppositeSideDailyLimitChanged(uint256 newLimit);
+    event ExecutionDailyLimitChanged(uint256 newLimit);
 
     function getBridgeInterfacesVersion() public pure returns(uint64 major, uint64 minor, uint64 patch) {
         return (2, 1, 0);
@@ -66,8 +66,8 @@ contract BasicBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("maxPerTx"))];
     }
 
-    function oppositeSideMaxPerTx() public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked("oppositeSideMaxPerTx"))];
+    function executionMaxPerTx() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))];
     }
 
     function setInitialize(bool _status) internal {
@@ -91,18 +91,18 @@ contract BasicBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("dailyLimit"))];
     }
 
-    function setOppositeSideDailyLimit(uint256 _dailyLimit) public onlyOwner {
-        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _dailyLimit;
-        emit OppositeSideDailyLimitChanged(_dailyLimit);
+    function setExecutionDailyLimit(uint256 _dailyLimit) public onlyOwner {
+        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _dailyLimit;
+        emit ExecutionDailyLimitChanged(_dailyLimit);
     }
 
-    function oppositeSideDailyLimit() public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))];
+    function executionDailyLimit() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))];
     }
 
-    function setOppositeSideMaxPerTx(uint256 _maxPerTx) external onlyOwner {
-        require(_maxPerTx < oppositeSideDailyLimit());
-        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _maxPerTx;
+    function setExecutionMaxPerTx(uint256 _maxPerTx) external onlyOwner {
+        require(_maxPerTx < executionDailyLimit());
+        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _maxPerTx;
     }
 
     function setMaxPerTx(uint256 _maxPerTx) external onlyOwner {
@@ -120,9 +120,9 @@ contract BasicBridge is EternalStorage, Validatable {
         return dailyLimit() >= nextLimit && _amount <= maxPerTx() && _amount >= minPerTx();
     }
 
-    function withinOppositeSideLimit(uint256 _amount) public view returns(bool) {
+    function withinExecutionLimit(uint256 _amount) public view returns(bool) {
         uint256 nextLimit = totalExecutedPerDay(getCurrentDay()).add(_amount);
-        return oppositeSideDailyLimit() >= nextLimit && _amount <= oppositeSideMaxPerTx();
+        return executionDailyLimit() >= nextLimit && _amount <= executionMaxPerTx();
     }
 
     function claimTokens(address _token, address _to) public onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -12,6 +12,7 @@ contract BasicBridge is EternalStorage, Validatable {
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
     event DailyLimitChanged(uint256 newLimit);
+    event OppositeSideDailyLimitChanged(uint256 newLimit);
 
     function getBridgeInterfacesVersion() public pure returns(uint64 major, uint64 minor, uint64 patch) {
         return (2, 1, 0);
@@ -49,6 +50,14 @@ contract BasicBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))];
     }
 
+    function setTotalExecutedPerDay(uint256 _day, uint256 _value) internal {
+        uintStorage[keccak256("totalExecutedPerDay", _day)] = _value;
+    }
+
+    function totalExecutedPerDay(uint256 _day) public view returns(uint256) {
+        return uintStorage[keccak256("totalExecutedPerDay", _day)];
+    }
+
     function minPerTx() public view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked("minPerTx"))];
     }
@@ -84,6 +93,7 @@ contract BasicBridge is EternalStorage, Validatable {
 
     function setOppositeSideDailyLimit(uint256 _dailyLimit) public onlyOwner {
         uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _dailyLimit;
+        emit OppositeSideDailyLimitChanged(_dailyLimit);
     }
 
     function oppositeSideDailyLimit() public view returns(uint256) {
@@ -111,7 +121,7 @@ contract BasicBridge is EternalStorage, Validatable {
     }
 
     function withinOppositeSideLimit(uint256 _amount) public view returns(bool) {
-        uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
+        uint256 nextLimit = totalExecutedPerDay(getCurrentDay()).add(_amount);
         return oppositeSideDailyLimit() >= nextLimit && _amount <= oppositeSideMaxPerTx();
     }
 

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -51,11 +51,11 @@ contract BasicBridge is EternalStorage, Validatable {
     }
 
     function setTotalExecutedPerDay(uint256 _day, uint256 _value) internal {
-        uintStorage[keccak256("totalExecutedPerDay", _day)] = _value;
+        uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))] = _value;
     }
 
     function totalExecutedPerDay(uint256 _day) public view returns(uint256) {
-        return uintStorage[keccak256("totalExecutedPerDay", _day)];
+        return uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))];
     }
 
     function minPerTx() public view returns(uint256) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -57,6 +57,10 @@ contract BasicBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("maxPerTx"))];
     }
 
+    function oppositeSideMaxPerTx() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("oppositeSideMaxPerTx"))];
+    }
+
     function setInitialize(bool _status) internal {
         boolStorage[keccak256(abi.encodePacked("isInitialized"))] = _status;
     }
@@ -78,6 +82,19 @@ contract BasicBridge is EternalStorage, Validatable {
         return uintStorage[keccak256(abi.encodePacked("dailyLimit"))];
     }
 
+    function setOppositeSideDailyLimit(uint256 _dailyLimit) public onlyOwner {
+        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _dailyLimit;
+    }
+
+    function oppositeSideDailyLimit() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))];
+    }
+
+    function setOppositeSideMaxPerTx(uint256 _maxPerTx) external onlyOwner {
+        require(_maxPerTx < oppositeSideDailyLimit());
+        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _maxPerTx;
+    }
+
     function setMaxPerTx(uint256 _maxPerTx) external onlyOwner {
         require(_maxPerTx < dailyLimit());
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
@@ -91,6 +108,19 @@ contract BasicBridge is EternalStorage, Validatable {
     function withinLimit(uint256 _amount) public view returns(bool) {
         uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
         return dailyLimit() >= nextLimit && _amount <= maxPerTx() && _amount >= minPerTx();
+    }
+
+    function withinOppositeSideLimit(uint256 _amount) public view returns(bool) {
+        uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
+        return oppositeSideDailyLimit() >= nextLimit && _amount <= oppositeSideMaxPerTx();
+    }
+
+    function outOfLimitAmount() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
+    }
+
+    function setOutOfLimitAmount(uint256 _value) internal {
+        uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
     }
 
     function claimTokens(address _token, address _to) public onlyOwner {

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -40,7 +40,7 @@ contract BasicForeignBridge is EternalStorage, Validatable {
         return boolStorage[keccak256(abi.encodePacked("relayedMessages", _txHash))];
     }
 
-    function messageWithinLimits(uint256) internal returns(bool) {
+    function messageWithinLimits(uint256) internal view returns(bool) {
         return true;
     }
 

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -149,7 +149,7 @@ contract BasicHomeBridge is EternalStorage, Validatable {
         return Message.requiredMessageLength();
     }
 
-    function affirmationWithinLimits(uint256) internal returns(bool) {
+    function affirmationWithinLimits(uint256) internal view returns(bool) {
         return true;
     }
 

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -155,45 +155,4 @@ contract BasicHomeBridge is EternalStorage, Validatable {
 
     function onFailedAffirmation(address, uint256, bytes32) internal {
     }
-
-    function outOfLimitAmount() public view returns(uint256) {
-        return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
-    }
-
-    function setOutOfLimitAmount(uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
-    }
-
-    function fixAssetsAboveLimits(bytes32 txHash, bool unlock_on_foreign) external onlyOwner {
-        require(!fixedAssets(txHash));
-        address recipient;
-        uint256 value;
-        (recipient, value) = txAboveLimits(txHash);
-        require(recipient != address(0) && value > 0);
-        setOutOfLimitAmount(outOfLimitAmount().sub(value));
-        if (unlock_on_foreign) {
-            emit UserRequestForSignature(recipient, value);
-        }
-        setFixedAssets(txHash, true);
-    }
-
-    function txAboveLimits(bytes32 _txHash) internal view returns(address recipient, uint256 value) {
-        bytes memory data = bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))];
-        assembly {
-            recipient := and(mload(add(data, 20)), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-            value := mload(add(data, 52))
-        }
-    }
-
-    function setTxAboveLimits(address _recipient, uint256 _value, bytes32 _txHash) internal {
-        bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))] = abi.encodePacked(_recipient, _value);
-    }
-
-    function setFixedAssets(bytes32 _txHash, bool _status) internal {
-        boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))] = _status;
-    }
-
-    function fixedAssets(bytes32 _txHash) public view returns(bool) {
-        return boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))];
-    }
 }

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -6,7 +6,7 @@ import "../libraries/SafeMath.sol";
 import "../upgradeability/OwnedUpgradeabilityProxy.sol";
 
 
-contract OverdrawManagement is EternalStorage, OwnedUpgradeabilityProxy, Validatable {
+contract OverdrawManagement is OwnedUpgradeabilityProxy, EternalStorage, Validatable {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -1,12 +1,11 @@
 pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
-import "./Validatable.sol";
 import "../libraries/SafeMath.sol";
 import "../upgradeability/OwnedUpgradeabilityProxy.sol";
 
 
-contract OverdrawManagement is OwnedUpgradeabilityProxy, EternalStorage, Validatable {
+contract OverdrawManagement is OwnedUpgradeabilityProxy, EternalStorage {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -3,14 +3,15 @@ pragma solidity 0.4.24;
 import "../upgradeability/EternalStorage.sol";
 import "./Validatable.sol";
 import "../libraries/SafeMath.sol";
+import "../upgradeability/OwnedUpgradeabilityProxy.sol";
 
 
-contract OverdrawManagement is EternalStorage, Validatable {
+contract OverdrawManagement is EternalStorage, OwnedUpgradeabilityProxy, Validatable {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);
 
-    function fixAssetsAboveLimits(bytes32 txHash, bool unlockOnForeign) external onlyOwner {
+    function fixAssetsAboveLimits(bytes32 txHash, bool unlockOnForeign) external onlyProxyOwner {
         require(!fixedAssets(txHash));
         address recipient;
         uint256 value;

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -36,20 +36,16 @@ contract OverdrawManagement is EternalStorage, Validatable {
     }
 
     function txAboveLimits(bytes32 _txHash) internal view returns(address recipient, uint256 value) {
-        bytes memory data = bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))];
-        assembly {
-            recipient := and(mload(add(data, 20)), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-            value := mload(add(data, 52))
-        }
+        recipient = addressStorage[keccak256(abi.encodePacked("txOutOfLimitRecipient", _txHash))];
+        value = uintStorage[keccak256(abi.encodePacked("txOutOfLimitValue", _txHash))];
     }
 
     function setTxAboveLimits(address _recipient, uint256 _value, bytes32 _txHash) internal {
-        bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))] = abi.encodePacked(_recipient, _value);
+        addressStorage[keccak256(abi.encodePacked("txOutOfLimitRecipient", _txHash))] = _recipient;
+        uintStorage[keccak256(abi.encodePacked("txOutOfLimitValue", _txHash))] = _value;
     }
 
     function setFixedAssets(bytes32 _txHash, bool _status) internal {
         boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))] = _status;
     }
-
-
 }

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -1,0 +1,55 @@
+pragma solidity 0.4.24;
+
+import "../upgradeability/EternalStorage.sol";
+import "./Validatable.sol";
+import "../libraries/SafeMath.sol";
+
+
+contract OverdrawManagement is EternalStorage, Validatable {
+    using SafeMath for uint256;
+
+    event UserRequestForSignature(address recipient, uint256 value);
+
+    function fixAssetsAboveLimits(bytes32 txHash, bool unlockOnForeign) external onlyOwner {
+        require(!fixedAssets(txHash));
+        address recipient;
+        uint256 value;
+        (recipient, value) = txAboveLimits(txHash);
+        require(recipient != address(0) && value > 0);
+        setOutOfLimitAmount(outOfLimitAmount().sub(value));
+        if (unlockOnForeign) {
+            emit UserRequestForSignature(recipient, value);
+        }
+        setFixedAssets(txHash, true);
+    }
+
+    function outOfLimitAmount() public view returns(uint256) {
+        return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
+    }
+
+    function fixedAssets(bytes32 _txHash) public view returns(bool) {
+        return boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))];
+    }
+
+    function setOutOfLimitAmount(uint256 _value) internal {
+        uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
+    }
+
+    function txAboveLimits(bytes32 _txHash) internal view returns(address recipient, uint256 value) {
+        bytes memory data = bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))];
+        assembly {
+            recipient := and(mload(add(data, 20)), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            value := mload(add(data, 52))
+        }
+    }
+
+    function setTxAboveLimits(address _recipient, uint256 _value, bytes32 _txHash) internal {
+        bytesStorage[keccak256(abi.encodePacked("txOutOfLimit", _txHash))] = abi.encodePacked(_recipient, _value);
+    }
+
+    function setFixedAssets(bytes32 _txHash, bool _status) internal {
+        boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))] = _status;
+    }
+
+
+}

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -51,7 +51,7 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
     }
 
     function onExecuteMessage(address _recipient, uint256 _amount) internal returns(bool) {
-        setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_amount));
+        setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -31,8 +31,8 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _homeDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("oppositeSideMaxPerTx"))] = _homeMaxPerTx;
+        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
+        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setInitialize(true);
         return isInitialized();
     }
@@ -61,7 +61,7 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
     }
 
     function messageWithinLimits(uint256 _amount) internal returns(bool) {
-        return withinOppositeSideLimit(_amount);
+        return withinExecutionLimit(_amount);
     }
 
     function onFailedMessage(address, uint256, bytes32) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -60,7 +60,7 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 
-    function messageWithinLimits(uint256 _amount) internal returns(bool) {
+    function messageWithinLimits(uint256 _amount) internal view returns(bool) {
         return withinExecutionLimit(_amount);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -7,9 +7,10 @@ import "../../IBlockReward.sol";
 import "../../ERC677Receiver.sol";
 import "../BasicHomeBridge.sol";
 import "../ERC677Bridge.sol";
+import "../OverdrawManagement.sol";
 
 
-contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
+contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, OverdrawManagement {
 
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -92,7 +92,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
         uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))] = _amount;
     }
 
-    function affirmationWithinLimits(uint256 _amount) internal returns(bool) {
+    function affirmationWithinLimits(uint256 _amount) internal view returns(bool) {
         return withinExecutionLimit(_amount);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -98,6 +98,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {
         setOutOfLimitAmount(outOfLimitAmount().add(_value));
+        setTxAboveLimits(_recipient, _value, _txHash);
         emit AmountLimitExceeded(_recipient, _value, _txHash);
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -52,8 +52,8 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
-        uintStorage[keccak256(abi.encodePacked("oppositeSideDailyLimit"))] = _foreignDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("oppositeSideMaxPerTx"))] = _foreignMaxPerTx;
+        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
+        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
         setInitialize(true);
 
         return isInitialized();
@@ -93,7 +93,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
     }
 
     function affirmationWithinLimits(uint256 _amount) internal returns(bool) {
-        return withinOppositeSideLimit(_amount);
+        return withinExecutionLimit(_amount);
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -77,6 +77,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value) internal returns(bool) {
+        setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_value));
         IBlockReward blockReward = blockRewardContract();
         require(blockReward != address(0));
         blockReward.addExtraReceiver(_value, _recipient);

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -97,6 +97,10 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge {
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {
+        address recipient;
+        uint256 value;
+        (recipient, value) = txAboveLimits(_txHash);
+        require(value == 0);
         setOutOfLimitAmount(outOfLimitAmount().add(_value));
         setTxAboveLimits(_recipient, _value, _txHash);
         emit AmountLimitExceeded(_recipient, _value, _txHash);

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -101,7 +101,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         address recipient;
         uint256 value;
         (recipient, value) = txAboveLimits(_txHash);
-        require(value == 0);
+        require(recipient == address(0) && value == 0);
         setOutOfLimitAmount(outOfLimitAmount().add(_value));
         setTxAboveLimits(_recipient, _value, _txHash);
         emit AmountLimitExceeded(_recipient, _value, _txHash);

--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -9,6 +9,10 @@ const { createMessage, sign, signatureToVRS } = require('../helpers/helpers');
 const halfEther = web3.toBigNumber(web3.toWei(0.5, "ether"));
 const requireBlockConfirmations = 8;
 const gasPrice = web3.toWei('1', 'gwei');
+const oneEther = web3.toBigNumber(web3.toWei(1, "ether"));
+const homeDailyLimit = oneEther
+const homeMaxPerTx = halfEther
+const maxPerTx = halfEther
 
 contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
   let validatorContract, authorities, owner, token;
@@ -30,14 +34,15 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
       false.should.be.equal(await foreignBridge.isInitialized())
       '0'.should.be.bignumber.equal(await foreignBridge.requiredBlockConfirmations())
 
-      await foreignBridge.initialize(ZERO_ADDRESS, token.address, requireBlockConfirmations, gasPrice).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.initialize(validatorContract.address, ZERO_ADDRESS, requireBlockConfirmations, gasPrice).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.initialize(validatorContract.address, token.address, 0, gasPrice).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, 0).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.initialize(validatorContract.address, owner, requireBlockConfirmations, gasPrice).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.initialize(owner, token.address, requireBlockConfirmations, gasPrice).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(ZERO_ADDRESS, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(validatorContract.address, ZERO_ADDRESS, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(validatorContract.address, token.address, 0, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, 0, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(validatorContract.address, owner, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(owner, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, halfEther, homeMaxPerTx).should.be.rejectedWith(ERROR_MSG);
 
-      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice);
+      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx);
 
       token.address.should.be.equal(await foreignBridge.erc20token());
       true.should.be.equal(await foreignBridge.isInitialized())
@@ -63,7 +68,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
     beforeEach(async () => {
       foreignBridge = await ForeignBridge.new()
       token = await ERC677BridgeToken.new("Some ERC20", "RSZT", 18);
-      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice);
+      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx);
       await token.mint(foreignBridge.address,value);
     })
 
@@ -143,6 +148,45 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
 
       await foreignBridge.executeSignatures([vrs2.v], [vrs2.r], [vrs2.s], message2).should.be.rejectedWith(ERROR_MSG)
     })
+
+    it('should not allow withdraw over home max tx limit', async () => {
+      const recipientAccount = accounts[3];
+      const invalidValue = web3.toBigNumber(web3.toWei(0.75, "ether"));
+      await token.mint(foreignBridge.address, web3.toBigNumber(web3.toWei(5, "ether")));
+
+      const transactionHash = "0x35d3818e50234655f6aebb2a1cfbf30f59568d8a4ec72066fac5a25dbe7b8121";
+      const message = createMessage(recipientAccount, invalidValue, transactionHash, foreignBridge.address);
+      const signature = await sign(authorities[0], message)
+      const vrs = signatureToVRS(signature);
+
+      await foreignBridge.executeSignatures([vrs.v], [vrs.r], [vrs.s], message).should.be.rejectedWith(ERROR_MSG)
+    })
+
+    it('should not allow withdraw over daily home limit', async () => {
+      const recipientAccount = accounts[3];
+      await token.mint(foreignBridge.address, web3.toBigNumber(web3.toWei(5, "ether")));
+
+      const transactionHash = "0x35d3818e50234655f6aebb2a1cfbf30f59568d8a4ec72066fac5a25dbe7b8121";
+      const message = createMessage(recipientAccount, halfEther, transactionHash, foreignBridge.address);
+      const signature = await sign(authorities[0], message)
+      const vrs = signatureToVRS(signature);
+
+      await foreignBridge.executeSignatures([vrs.v], [vrs.r], [vrs.s], message).should.be.fulfilled
+
+      const transactionHash2 = "0x69debd8fd1923c9cb3cd8ef6461e2740b2d037943b941729d5a47671a2bb8712";
+      const message2 = createMessage(recipientAccount, halfEther, transactionHash2, foreignBridge.address);
+      const signature2 = await sign(authorities[0], message2)
+      const vrs2 = signatureToVRS(signature2);
+
+      await foreignBridge.executeSignatures([vrs2.v], [vrs2.r], [vrs2.s], message2).should.be.fulfilled
+
+      const transactionHash3 = "0x022695428093bb292db8e48bd1417c5e1b84c0bf673bd0fff23ed0fb6495b872";
+      const message3 = createMessage(recipientAccount, halfEther, transactionHash3, foreignBridge.address);
+      const signature3 = await sign(authorities[0], message3)
+      const vrs3 = signatureToVRS(signature3);
+
+      await foreignBridge.executeSignatures([vrs3.v], [vrs3.r], [vrs3.s], message3).should.be.rejectedWith(ERROR_MSG)
+    })
   })
 
   describe('#withdraw with 2 minimum signatures', async () => {
@@ -155,7 +199,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
       ownerOfValidatorContract = accounts[3]
       await multisigValidatorContract.initialize(2, twoAuthorities, ownerOfValidatorContract, {from: ownerOfValidatorContract})
       foreignBridgeWithMultiSignatures = await ForeignBridge.new()
-      await foreignBridgeWithMultiSignatures.initialize(multisigValidatorContract.address, token.address, requireBlockConfirmations, gasPrice, {from: ownerOfValidatorContract});
+      await foreignBridgeWithMultiSignatures.initialize(multisigValidatorContract.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx, {from: ownerOfValidatorContract});
       await token.mint(foreignBridgeWithMultiSignatures.address,value);
     })
 
@@ -203,7 +247,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
       const value = web3.toBigNumber(web3.toWei(0.5, "ether"));
       const foreignBridgeWithThreeSigs = await ForeignBridge.new()
 
-      await foreignBridgeWithThreeSigs.initialize(validatorContractWith3Signatures.address, erc20Token.address, requireBlockConfirmations, gasPrice);
+      await foreignBridgeWithThreeSigs.initialize(validatorContractWith3Signatures.address, erc20Token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx);
       await erc20Token.mint(foreignBridgeWithThreeSigs.address, value);
 
       const txHash = "0x35d3818e50234655f6aebb2a1cfbf30f59568d8a4ec72066fac5a25dbe7b8121";
@@ -252,7 +296,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
       await foreignBridgeProxy.upgradeTo('1', foreignBridgeImpl.address).should.be.fulfilled;
 
       foreignBridgeProxy = await ForeignBridge.at(foreignBridgeProxy.address);
-      await foreignBridgeProxy.initialize(validatorsProxy.address, token.address, requireBlockConfirmations, gasPrice)
+      await foreignBridgeProxy.initialize(validatorsProxy.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx)
 
       // Deploy V2
       let foreignImplV2 = await ForeignBridgeV2.new();
@@ -272,7 +316,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
 
       const storageProxy = await EternalStorageProxy.new().should.be.fulfilled;
       const foreignBridge =  await ForeignBridge.new();
-      const data = foreignBridge.initialize.request(validatorsAddress, tokenAddress, requireBlockConfirmations, gasPrice).params[0].data
+      const data = foreignBridge.initialize.request(validatorsAddress, tokenAddress, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx).params[0].data
 
       await storageProxy.upgradeToAndCall('1', foreignBridge.address, data).should.be.fulfilled;
 
@@ -288,7 +332,7 @@ contract('ForeignBridge_ERC20_to_Native', async (accounts) => {
       token = await ERC677BridgeToken.new("Some ERC20", "RSZT", 18);
       const foreignBridge = await ForeignBridge.new();
 
-      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice);
+      await foreignBridge.initialize(validatorContract.address, token.address, requireBlockConfirmations, gasPrice, maxPerTx, homeDailyLimit, homeMaxPerTx);
       const tokenSecond = await ERC677BridgeToken.new("Roman Token", "RST", 18);
 
       await tokenSecond.mint(accounts[0], halfEther).should.be.fulfilled;

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -696,7 +696,7 @@ contract('HomeBridge_ERC20_to_Native', async (accounts) => {
 
       await homeBridge.fixAssetsAboveLimits(invalidTxHash, true).should.be.rejectedWith(ERROR_MSG)
     })
-    it('Should fail if not called by owner', async () => {
+    it('Should fail if not called by proxyOwner', async () => {
       const recipient = accounts[5];
       const value = oneEther;
       const transactionHash = "0x806335163828a8eda675cff9c84fa6e6c7cf06bb44cc6ec832e42fe789d01415";

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -447,6 +447,23 @@ contract('HomeBridge_ERC20_to_Native', async (accounts) => {
         value,
         transactionHash: transactionHash3
       });
+
+      const outOfLimitAmount = await homeBridge.outOfLimitAmount()
+
+      outOfLimitAmount.should.be.bignumber.equal(halfEther)
+
+      const transactionHash4 = "0xc9ffe298d85ec5c515153608924b7bdcf1835539813dcc82cdbcc071170c3196";
+      const { logs: logs4 } = await homeBridge.executeAffirmation(recipient, value, transactionHash4, {from: authorities[0]}).should.be.fulfilled;
+
+      logs4[0].event.should.be.equal("AmountLimitExceeded");
+      logs4[0].args.should.be.deep.equal({
+        recipient,
+        value,
+        transactionHash: transactionHash4
+      });
+
+      const newOutOfLimitAmount = await homeBridge.outOfLimitAmount()
+      newOutOfLimitAmount.should.be.bignumber.equal(oneEther)
     })
   })
 

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -400,6 +400,22 @@ contract('HomeBridge_ERC20_to_Native', async (accounts) => {
         transactionHash
       });
     })
+    it('should fail if txHash already set as above of limits', async () => {
+      const recipient = accounts[5];
+      const value = oneEther;
+      const transactionHash = "0x806335163828a8eda675cff9c84fa6e6c7cf06bb44cc6ec832e42fe789d01415";
+      const {logs} = await homeBridge.executeAffirmation(recipient, value, transactionHash, {from: authorities[0]}).should.be.fulfilled;
+
+      logs[0].event.should.be.equal("AmountLimitExceeded");
+      logs[0].args.should.be.deep.equal({
+        recipient,
+        value,
+        transactionHash
+      });
+
+      await homeBridge.executeAffirmation(recipient, value, transactionHash, {from: authorities[0]}).should.be.rejectedWith(ERROR_MSG)
+      await homeBridge.executeAffirmation(accounts[6], value, transactionHash, {from: authorities[0]}).should.be.rejectedWith(ERROR_MSG)
+    })
     it('should not allow execute affirmation over daily foreign limit', async () => {
       await blockRewardContract.sendTransaction({
         from: accounts[2],


### PR DESCRIPTION
Closes #110 

Added functionality to `ERC-TO-NATIVE` mode. Once we agree on the changes, I can extend them to others bridge modes and update deploy scripts.