### PR TITLE
Extend ERC677BridgeToken contract for `xDai-POA` bridge

### DIFF
--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -14,6 +14,8 @@ contract ERC677BridgeToken is
     MintableToken {
 
     address public bridgeContract;
+    address public blockRewardContract;
+    address public validatorSetContract;
 
     event ContractFallbackCallFailed(address from, address to, uint value);
 
@@ -28,8 +30,28 @@ contract ERC677BridgeToken is
         bridgeContract = _bridgeContract;
     }
 
+    function setBlockRewardContract(address _blockRewardContract) onlyOwner public {
+        require(_blockRewardContract != address(0) && isContract(_blockRewardContract));
+        blockRewardContract = _blockRewardContract;
+    }
+
+    function setValidatorSetContract(address _validatorSetContract) onlyOwner public {
+        require(_validatorSetContract != address(0) && isContract(_validatorSetContract));
+        validatorSetContract = _validatorSetContract;
+    }
+
     modifier validRecipient(address _recipient) {
         require(_recipient != address(0) && _recipient != address(this));
+        _;
+    }
+
+    modifier onlyBlockRewardContract() {
+        require(msg.sender == blockRewardContract);
+        _;
+    }
+
+    modifier onlyValidatorSetContract() {
+        require(msg.sender == validatorSetContract);
         _;
     }
 
@@ -104,5 +126,33 @@ contract ERC677BridgeToken is
         require(token.transfer(_to, balance));
     }
 
+    function mintReward(address[] _receivers, uint256[] _rewards) external onlyBlockRewardContract {
+        for (uint256 i = 0; i < _receivers.length; i++) {
+            address to = _receivers[i];
+            uint256 amount = _rewards[i];
+
+            // Mint `amount` for `to`
+            totalSupply_ = totalSupply_.add(amount);
+            balances[to] = balances[to].add(amount);
+            emit Mint(to, amount);
+            emit Transfer(address(0), to, amount);
+        }
+    }
+
+    function stake(address _staker, uint256 _amount) external onlyValidatorSetContract {
+        // Transfer `_amount` from `_staker` to `validatorSetContract`
+        require(_amount <= balances[_staker]);
+        balances[_staker] = balances[_staker].sub(_amount);
+        balances[validatorSetContract] = balances[validatorSetContract].add(_amount);
+        emit Transfer(_staker, validatorSetContract, _amount);
+    }
+
+    function withdraw(address _staker, uint256 _amount) external onlyValidatorSetContract {
+        // Transfer `_amount` from `validatorSetContract` to `_staker`
+        require(_amount <= balances[validatorSetContract]);
+        balances[validatorSetContract] = balances[validatorSetContract].sub(_amount);
+        balances[_staker] = balances[_staker].add(_amount);
+        emit Transfer(validatorSetContract, _staker, _amount);
+    }
 
 }


### PR DESCRIPTION
These changes add `mintReward`, `stake` and `withdraw` functions which are used by [DPoS contracts](https://github.com/poanetwork/pos-contracts/tree/master/contracts) ([`BlockReward`](https://github.com/poanetwork/pos-contracts/blob/13fd4a1c0bb40f97afcef5f2136b851d955dbb88/contracts/BlockRewardAuRa.sol#L44-L56) and [`ValidatorSet`](https://github.com/poanetwork/pos-contracts/blob/13fd4a1c0bb40f97afcef5f2136b851d955dbb88/contracts/abstracts/ValidatorSetBase.sol#L128-L144)).