### PR TITLE
Update deploy script to include Fee Manager options for ERC-TO-NATIVE mode

### DIFF
--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -6,7 +6,7 @@ import "./Ownable.sol";
 contract RewardableBridge is Ownable {
 
     function setFee(uint256 _fee) external onlyOwner {
-        require(feeManagerContract().delegatecall(abi.encodeWithSignature("setFee(uint256)", _fee)));
+        _setFee(feeManagerContract(), _fee);
     }
 
     function getFee() public view returns(uint256) {
@@ -30,6 +30,10 @@ contract RewardableBridge is Ownable {
     function setFeeManagerContract(address _feeManager) public onlyOwner {
         require(_feeManager == address(0) || isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+    }
+
+    function _setFee(address _feeManager, uint256 _fee) internal {
+        require(_feeManager.delegatecall(abi.encodeWithSignature("setFee(uint256)", _fee)));
     }
 
     function isContract(address _addr) internal view returns (bool)

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -47,24 +47,53 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         address _owner
     ) public returns(bool)
     {
-        require(!isInitialized());
-        require(_validatorContract != address(0) && isContract(_validatorContract));
-        require(_requiredBlockConfirmations > 0);
-        require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
-        require(_blockReward == address(0) || isContract(_blockReward));
-        require(_foreignMaxPerTx < _foreignDailyLimit);
-        require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
-        setOwner(_owner);
+        _initialize(
+            _validatorContract,
+            _dailyLimit,
+            _maxPerTx,
+            _minPerTx,
+            _homeGasPrice,
+            _requiredBlockConfirmations,
+            _blockReward,
+            _foreignDailyLimit,
+            _foreignMaxPerTx,
+            _owner
+        );
+        setInitialize(true);
+
+        return isInitialized();
+    }
+
+    function rewardableInitialize (
+        address _validatorContract,
+        uint256 _dailyLimit,
+        uint256 _maxPerTx,
+        uint256 _minPerTx,
+        uint256 _homeGasPrice,
+        uint256 _requiredBlockConfirmations,
+        address _blockReward,
+        uint256 _foreignDailyLimit,
+        uint256 _foreignMaxPerTx,
+        address _owner,
+        address _feeManager,
+        uint256 _fee
+    ) public returns(bool)
+    {
+        _initialize(
+            _validatorContract,
+            _dailyLimit,
+            _maxPerTx,
+            _minPerTx,
+            _homeGasPrice,
+            _requiredBlockConfirmations,
+            _blockReward,
+            _foreignDailyLimit,
+            _foreignMaxPerTx,
+            _owner
+        );
+        require(isContract(_feeManager));
+        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        require(_feeManager.delegatecall(abi.encodeWithSignature("setFee(uint256)", _fee)));
         setInitialize(true);
 
         return isInitialized();
@@ -85,6 +114,39 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
     function setBlockRewardContract(address _blockReward) public onlyOwner {
         require(_blockReward != address(0) && isContract(_blockReward) && (IBlockReward(_blockReward).bridgesAllowedLength() != 0));
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
+    }
+
+    function _initialize (
+        address _validatorContract,
+        uint256 _dailyLimit,
+        uint256 _maxPerTx,
+        uint256 _minPerTx,
+        uint256 _homeGasPrice,
+        uint256 _requiredBlockConfirmations,
+        address _blockReward,
+        uint256 _foreignDailyLimit,
+        uint256 _foreignMaxPerTx,
+        address _owner
+    ) internal
+    {
+        require(!isInitialized());
+        require(_validatorContract != address(0) && isContract(_validatorContract));
+        require(_requiredBlockConfirmations > 0);
+        require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
+        require(_blockReward == address(0) || isContract(_blockReward));
+        require(_foreignMaxPerTx < _foreignDailyLimit);
+        require(_owner != address(0));
+        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
+        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
+        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
+        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
+        setOwner(_owner);
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value) internal returns(bool) {

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -93,7 +93,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         );
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
-        require(_feeManager.delegatecall(abi.encodeWithSignature("setFee(uint256)", _fee)));
+        _setFee(_feeManager, _fee);
         setInitialize(true);
 
         return isInitialized();

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,7 +1,7 @@
 #BRIDGE_MODE=ERC_TO_ERC
 BRIDGE_MODE=NATIVE_TO_ERC
 DEPLOYMENT_ACCOUNT_PRIVATE_KEY=67..14
-DEPLOYMENT_GAS_LIMIT=5000000
+DEPLOYMENT_GAS_LIMIT=6000000
 HOME_DEPLOYMENT_GAS_PRICE=10000000000
 FOREIGN_DEPLOYMENT_GAS_PRICE=10000000000
 GET_RECEIPT_INTERVAL_IN_MILLISECONDS=3000
@@ -39,6 +39,16 @@ REQUIRED_NUMBER_OF_VALIDATORS=1
 #If several validators are used, list them separated by space without quotes
 #E.g. VALIDATORS=0x 0x 0x
 VALIDATORS=0x
+#for erc_to_native mode
+#Set to true if RewardableValidators will be used and fee will be charged
+REWARDABLE_VALIDATORS=false
+#If REWARDABLE_VALIDATORS=true, list validators accounts were rewards should be transferred separated by space without quotes
+#E.g. VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
+VALIDATORS_REWARD_ACCOUNTS=0x
+
+# Fee to be charged for each transfer:
+# E.g. 0.1% fee
+BRIDGE_FEE=0.001
 
 #for bridge native_to_erc mode
 DEPLOY_REWARDABLE_TOKEN=false

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -48,10 +48,11 @@ FOREIGN_REWARDABLE=false
 #E.g. VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 VALIDATORS_REWARD_ACCOUNTS=0x
 
-# Fee to be charged for each transfer:
+# Fee to be charged for each transfer on Home:
 # E.g. 0.1% fee
-BRIDGE_FEE=0.001
-
+HOME_TRANSACTIONS_FEE=0.001
+# Fee to be charged for each transfer on Foreign:
+FOREIGN_TRANSACTIONS_FEE=0.001
 #for bridge native_to_erc mode
 DEPLOY_REWARDABLE_TOKEN=false
 DPOS_VALIDATOR_SET_ADDRESS=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -40,9 +40,11 @@ REQUIRED_NUMBER_OF_VALIDATORS=1
 #E.g. VALIDATORS=0x 0x 0x
 VALIDATORS=0x
 #for erc_to_native mode
-#Set to true if RewardableValidators will be used and fee will be charged
-REWARDABLE_VALIDATORS=false
-#If REWARDABLE_VALIDATORS=true, list validators accounts were rewards should be transferred separated by space without quotes
+#Set to true if fee will be charged on home side
+HOME_REWARDABLE=false
+#Set to true if fee will be charged on foreign side
+FOREIGN_REWARDABLE=false
+#If HOME_REWARDABLE or FOREIGN_REWARDABLE set to true, list validators accounts were rewards should be transferred separated by space without quotes
 #E.g. VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 VALIDATORS_REWARD_ACCOUNTS=0x
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -338,8 +338,12 @@ FOREIGN_REWARDABLE=false
 # Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
 VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 
-# Fee to be charged for each transfer
-# Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
+# Fee to be charged for each transfer on Home network
+# Makes sense only when HOME_REWARDABLE=true
 # e.g. 0.1% fee
-BRIDGE_FEE=0.001
+HOME_TRANSACTIONS_FEE=0.001
+# Fee to be charged for each transfer on Foreign network
+# Makes sense only when FOREIGN_REWARDABLE=true
+# e.g. 0.1% fee
+FOREIGN_TRANSACTIONS_FEE=0.001
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -328,4 +328,16 @@ REQUIRED_NUMBER_OF_VALIDATORS=1
 # the Foreign network to confirm that the finalized agreement was transferred
 # correctly to the Foreign network.
 VALIDATORS=0x 0x 0x
+
+
+# The flag defining whether to use RewardableValidators contract and set a fee manager contract
+REWARDABLE_VALIDATORS=false
+# List validators accounts were rewards should be transferred separated by space without quotes
+# Makes sense only when REWARDABLE_VALIDATORS=true
+VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
+
+# Fee to be charged for each transfer
+# Makes sense only when REWARDABLE_VALIDATORS=true
+# e.g. 0.1% fee
+BRIDGE_FEE=0.001
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -330,14 +330,16 @@ REQUIRED_NUMBER_OF_VALIDATORS=1
 VALIDATORS=0x 0x 0x
 
 
-# The flag defining whether to use RewardableValidators contract and set a fee manager contract
-REWARDABLE_VALIDATORS=false
+# The flag defining whether to use RewardableValidators contract and set a fee manager contract on Home network
+HOME_REWARDABLE=false
+# The flag defining whether to use RewardableValidators contract and set a fee manager contract on Foreign network
+FOREIGN_REWARDABLE=false
 # List validators accounts were rewards should be transferred separated by space without quotes
-# Makes sense only when REWARDABLE_VALIDATORS=true
+# Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
 VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 
 # Fee to be charged for each transfer
-# Makes sense only when REWARDABLE_VALIDATORS=true
+# Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
 # e.g. 0.1% fee
 BRIDGE_FEE=0.001
 ```

--- a/deploy/src/deploymentUtils.js
+++ b/deploy/src/deploymentUtils.js
@@ -140,6 +140,13 @@ function privateKeyToAddress(privateKey) {
   return new Web3().eth.accounts.privateKeyToAccount(add0xPrefix(privateKey)).address
 }
 
+function logValidatorsAndRewardAccounts(validators, rewards) {
+  console.log(`VALIDATORS\n==========`)
+  validators.forEach((validator, index) => {
+    console.log(`${index + 1}: ${validator}, reward address ${rewards[index]}`)
+  })
+}
+
 module.exports = {
   deployContract,
   sendNodeRequest,
@@ -147,5 +154,6 @@ module.exports = {
   sendRawTx,
   sendRawTxHome,
   sendRawTxForeign,
-  privateKeyToAddress
+  privateKeyToAddress,
+  logValidatorsAndRewardAccounts
 }

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -2,7 +2,12 @@ const assert = require('assert')
 const Web3Utils = require('web3-utils')
 const env = require('../loadEnv')
 
-const { deployContract, privateKeyToAddress, sendRawTxHome } = require('../deploymentUtils')
+const {
+  deployContract,
+  privateKeyToAddress,
+  sendRawTxHome,
+  logValidatorsAndRewardAccounts
+} = require('../deploymentUtils')
 const { web3Home, deploymentPrivateKey, HOME_RPC_URL } = require('../web3')
 
 const EternalStorageProxy = require('../../../build/contracts/EternalStorageProxy.json')
@@ -76,8 +81,9 @@ async function deployHome() {
 
   if (isRewardableBridge) {
     console.log(
-      `REQUIRED_NUMBER_OF_VALIDATORS: ${REQUIRED_NUMBER_OF_VALIDATORS}, VALIDATORS: ${VALIDATORS}, VALIDATORS_REWARD_ACCOUNTS: ${VALIDATORS_REWARD_ACCOUNTS}, HOME_VALIDATORS_OWNER: ${HOME_VALIDATORS_OWNER}`
+      `REQUIRED_NUMBER_OF_VALIDATORS: ${REQUIRED_NUMBER_OF_VALIDATORS}, HOME_VALIDATORS_OWNER: ${HOME_VALIDATORS_OWNER}`
     )
+    logValidatorsAndRewardAccounts(VALIDATORS, VALIDATORS_REWARD_ACCOUNTS)
     initializeData = await bridgeValidatorsHome.methods
       .initialize(
         REQUIRED_NUMBER_OF_VALIDATORS,

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -28,13 +28,13 @@ const {
   HOME_REQUIRED_BLOCK_CONFIRMATIONS,
   FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
-  REWARDABLE_VALIDATORS,
+  HOME_REWARDABLE,
   BRIDGE_FEE
 } = env
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
 
-const isRewardableBridge = REWARDABLE_VALIDATORS === 'true'
+const isRewardableBridge = HOME_REWARDABLE === 'true'
 
 async function deployHome() {
   let homeNonce = await web3Home.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -29,7 +29,7 @@ const {
   FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
   HOME_REWARDABLE,
-  BRIDGE_FEE
+  HOME_TRANSACTIONS_FEE
 } = env
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
@@ -161,7 +161,7 @@ async function deployHome() {
     console.log('[Home] feeManager Implementation: ', feeManager.options.address)
     homeNonce++
 
-    const feeInWei = Web3Utils.toWei(BRIDGE_FEE.toString(), 'ether')
+    const feeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
     console.log('\ninitializing Home Bridge with fee contract:\n')
     initializeHomeBridgeData = await homeBridgeImplementation.methods
       .rewardableInitialize(

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -169,6 +169,25 @@ async function deployHome() {
 
     const feeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
     console.log('\ninitializing Home Bridge with fee contract:\n')
+    console.log(`Home Validators: ${storageValidatorsHome.options.address},
+  HOME_DAILY_LIMIT : ${HOME_DAILY_LIMIT} which is ${Web3Utils.fromWei(HOME_DAILY_LIMIT)} in eth,
+  HOME_MAX_AMOUNT_PER_TX: ${HOME_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
+      HOME_MAX_AMOUNT_PER_TX
+    )} in eth,
+  HOME_MIN_AMOUNT_PER_TX: ${HOME_MIN_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
+      HOME_MIN_AMOUNT_PER_TX
+    )} in eth,
+  HOME_GAS_PRICE: ${HOME_GAS_PRICE}, HOME_REQUIRED_BLOCK_CONFIRMATIONS : ${HOME_REQUIRED_BLOCK_CONFIRMATIONS},
+  BLOCK_REWARD_ADDRESS: ${BLOCK_REWARD_ADDRESS},
+  FOREIGN_DAILY_LIMIT: ${FOREIGN_DAILY_LIMIT} which is ${Web3Utils.fromWei(
+      FOREIGN_DAILY_LIMIT
+    )} in eth,
+  FOREIGN_MAX_AMOUNT_PER_TX: ${FOREIGN_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
+      FOREIGN_MAX_AMOUNT_PER_TX
+    )} in eth,
+  HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER},
+  Fee Manager: ${feeManager.options.address},
+  Fee: ${feeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%`)
     initializeHomeBridgeData = await homeBridgeImplementation.methods
       .rewardableInitialize(
         storageValidatorsHome.options.address,
@@ -195,7 +214,16 @@ async function deployHome() {
   HOME_MIN_AMOUNT_PER_TX: ${HOME_MIN_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
       HOME_MIN_AMOUNT_PER_TX
     )} in eth,
-  HOME_GAS_PRICE: ${HOME_GAS_PRICE}, HOME_REQUIRED_BLOCK_CONFIRMATIONS : ${HOME_REQUIRED_BLOCK_CONFIRMATIONS}`)
+  HOME_GAS_PRICE: ${HOME_GAS_PRICE}, HOME_REQUIRED_BLOCK_CONFIRMATIONS : ${HOME_REQUIRED_BLOCK_CONFIRMATIONS},
+  BLOCK_REWARD_ADDRESS: ${BLOCK_REWARD_ADDRESS},
+  FOREIGN_DAILY_LIMIT: ${FOREIGN_DAILY_LIMIT} which is ${Web3Utils.fromWei(
+      FOREIGN_DAILY_LIMIT
+    )} in eth,
+  FOREIGN_MAX_AMOUNT_PER_TX: ${FOREIGN_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
+      FOREIGN_MAX_AMOUNT_PER_TX
+    )} in eth,
+  HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER}
+  `)
     initializeHomeBridgeData = await homeBridgeImplementation.methods
       .initialize(
         storageValidatorsHome.options.address,

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -34,7 +34,7 @@ const {
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
 
-const useRewardableValidators = REWARDABLE_VALIDATORS === 'true'
+const isRewardableBridge = REWARDABLE_VALIDATORS === 'true'
 
 async function deployHome() {
   let homeNonce = await web3Home.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)
@@ -47,7 +47,7 @@ async function deployHome() {
   homeNonce++
 
   console.log('\ndeploying implementation for home validators')
-  const bridgeValidatorsContract = useRewardableValidators ? RewardableValidators : BridgeValidators
+  const bridgeValidatorsContract = isRewardableBridge ? RewardableValidators : BridgeValidators
   const bridgeValidatorsHome = await deployContract(bridgeValidatorsContract, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,
     nonce: homeNonce
@@ -74,7 +74,7 @@ async function deployHome() {
 
   let initializeData
 
-  if (useRewardableValidators) {
+  if (isRewardableBridge) {
     console.log(
       `REQUIRED_NUMBER_OF_VALIDATORS: ${REQUIRED_NUMBER_OF_VALIDATORS}, VALIDATORS: ${VALIDATORS}, VALIDATORS_REWARD_ACCOUNTS: ${VALIDATORS_REWARD_ACCOUNTS}, HOME_VALIDATORS_OWNER: ${HOME_VALIDATORS_OWNER}`
     )
@@ -152,7 +152,7 @@ async function deployHome() {
   let initializeHomeBridgeData
   homeBridgeImplementation.options.address = homeBridgeStorage.options.address
 
-  if (useRewardableValidators) {
+  if (isRewardableBridge) {
     console.log('\ndeploying implementation for fee manager')
     const feeManager = await deployContract(FeeManagerErcToNative, [], {
       from: DEPLOYMENT_ACCOUNT_ADDRESS,

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -21,6 +21,15 @@ const addressesValidator = envalid.makeValidator(addresses => {
   addresses.split(' ').forEach(validateAddress)
   return addresses
 })
+const validateRewardableAddresses = (validators, rewards) => {
+  const validatorsLength = validators ? validators.split(' ').length : 0
+  const validatorsRewardLength = rewards ? rewards.split(' ').length : 0
+  if (validatorsLength !== validatorsRewardLength) {
+    throw new Error(
+      `List of rewards accounts (${validatorsRewardLength} accounts) should be the same length as list of validators (${validatorsLength} accounts)`
+    )
+  }
+}
 
 const {
   BRIDGE_MODE,
@@ -98,21 +107,21 @@ if (BRIDGE_MODE === 'ERC_TO_NATIVE') {
   }
 }
 
-if (HOME_REWARDABLE === 'true' || FOREIGN_REWARDABLE === 'true') {
-  const validatorsLength = VALIDATORS ? VALIDATORS.split(' ').length : 0
-  const validatorsRewardLength = VALIDATORS_REWARD_ACCOUNTS
-    ? VALIDATORS_REWARD_ACCOUNTS.split(' ').length
-    : 0
-  if (validatorsLength !== validatorsRewardLength) {
-    throw new Error(
-      `List of rewards accounts (${validatorsRewardLength} accounts) should be the same length as list of validators (${validatorsLength} accounts)`
-    )
-  }
-
+if (HOME_REWARDABLE === 'true') {
+  validateRewardableAddresses(VALIDATORS, VALIDATORS_REWARD_ACCOUNTS)
   validations = {
     ...validations,
     VALIDATORS_REWARD_ACCOUNTS: addressesValidator(),
-    BRIDGE_FEE: envalid.num()
+    HOME_TRANSACTIONS_FEE: envalid.num()
+  }
+}
+
+if (FOREIGN_REWARDABLE === 'true') {
+  validateRewardableAddresses(VALIDATORS, VALIDATORS_REWARD_ACCOUNTS)
+  validations = {
+    ...validations,
+    VALIDATORS_REWARD_ACCOUNTS: addressesValidator(),
+    FOREIGN_TRANSACTIONS_FEE: envalid.num()
   }
 }
 

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -22,7 +22,7 @@ const addressesValidator = envalid.makeValidator(addresses => {
   return addresses
 })
 
-const { BRIDGE_MODE } = process.env
+const { BRIDGE_MODE, REWARDABLE_VALIDATORS, VALIDATORS, VALIDATORS_REWARD_ACCOUNTS } = process.env
 
 if (!validBridgeModes.includes(BRIDGE_MODE)) {
   throw new Error(`Invalid bridge mode: ${BRIDGE_MODE}`)
@@ -83,6 +83,24 @@ if (BRIDGE_MODE === 'ERC_TO_NATIVE') {
     BLOCK_REWARD_ADDRESS: addressValidator({
       default: ZERO_ADDRESS
     })
+  }
+}
+
+if (REWARDABLE_VALIDATORS === 'true') {
+  const validatorsLength = VALIDATORS ? VALIDATORS.split(' ').length : 0
+  const validatorsRewardLength = VALIDATORS_REWARD_ACCOUNTS
+    ? VALIDATORS_REWARD_ACCOUNTS.split(' ').length
+    : 0
+  if (validatorsLength !== validatorsRewardLength) {
+    throw new Error(
+      `List of rewards accounts (${validatorsRewardLength} accounts) should be the same length as list of validators (${validatorsLength} accounts)`
+    )
+  }
+
+  validations = {
+    ...validations,
+    VALIDATORS_REWARD_ACCOUNTS: addressesValidator(),
+    BRIDGE_FEE: envalid.num()
   }
 }
 

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -22,7 +22,13 @@ const addressesValidator = envalid.makeValidator(addresses => {
   return addresses
 })
 
-const { BRIDGE_MODE, REWARDABLE_VALIDATORS, VALIDATORS, VALIDATORS_REWARD_ACCOUNTS } = process.env
+const {
+  BRIDGE_MODE,
+  HOME_REWARDABLE,
+  FOREIGN_REWARDABLE,
+  VALIDATORS,
+  VALIDATORS_REWARD_ACCOUNTS
+} = process.env
 
 if (!validBridgeModes.includes(BRIDGE_MODE)) {
   throw new Error(`Invalid bridge mode: ${BRIDGE_MODE}`)
@@ -84,9 +90,15 @@ if (BRIDGE_MODE === 'ERC_TO_NATIVE') {
       default: ZERO_ADDRESS
     })
   }
+
+  if (FOREIGN_REWARDABLE === 'true') {
+    throw new Error(
+      `Collecting fees on Foreign Network on ${BRIDGE_MODE} bridge mode is not supported.`
+    )
+  }
 }
 
-if (REWARDABLE_VALIDATORS === 'true') {
+if (HOME_REWARDABLE === 'true' || FOREIGN_REWARDABLE === 'true') {
   const validatorsLength = VALIDATORS ? VALIDATORS.split(' ').length : 0
   const validatorsRewardLength = VALIDATORS_REWARD_ACCOUNTS
     ? VALIDATORS_REWARD_ACCOUNTS.split(' ').length


### PR DESCRIPTION
Closes #124 

In order to be able to initialize the bridge with Fee Manager address and Fee value, I had to add a new initialize method that accepted that 2 extra parameters because `setFeeManagerContract` and `setFee` methods can only be executed by the owner which can be different from `DEPLOYMENT_ACCOUNT`.