### PR TITLE
Separate fee into home fee and foreign fee

### DIFF
--- a/contracts/upgradeable_contracts/FeeTypes.sol
+++ b/contracts/upgradeable_contracts/FeeTypes.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.4.24;
+
+
+contract FeeTypes {
+    bytes32 internal constant HOME_FEE = keccak256(abi.encodePacked("home-fee"));
+    bytes32 internal constant FOREIGN_FEE = keccak256(abi.encodePacked("foreign-fee"));
+}

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -6,23 +6,7 @@ import "./FeeTypes.sol";
 
 contract RewardableBridge is Ownable, FeeTypes {
 
-    function setHomeFee(uint256 _fee) external onlyOwner {
-        _setFee(feeManagerContract(), _fee, HOME_FEE);
-    }
-
-    function setForeignFee(uint256 _fee) external onlyOwner {
-        _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
-    }
-
-    function getHomeFee() public view returns(uint256) {
-        return _getFee(HOME_FEE);
-    }
-
-    function getForeignFee() public view returns(uint256) {
-        return _getFee(FOREIGN_FEE);
-    }
-
-    function _getFee(bytes32 _feeType) public view returns(uint256) {
+    function _getFee(bytes32 _feeType) internal view returns(uint256) {
         uint256 fee;
         address feeManager = feeManagerContract();
         string memory method = _feeType == HOME_FEE ? "getHomeFee()" : "getForeignFee()";

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -1,18 +1,33 @@
 pragma solidity 0.4.24;
 
 import "./Ownable.sol";
+import "./FeeTypes.sol";
 
 
-contract RewardableBridge is Ownable {
+contract RewardableBridge is Ownable, FeeTypes {
 
-    function setFee(uint256 _fee) external onlyOwner {
-        _setFee(feeManagerContract(), _fee);
+    function setHomeFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
 
-    function getFee() public view returns(uint256) {
+    function setForeignFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
+    }
+
+    function getHomeFee() public view returns(uint256) {
+        return _getFee(HOME_FEE);
+    }
+
+    function getForeignFee() public view returns(uint256) {
+        return _getFee(FOREIGN_FEE);
+    }
+
+    function _getFee(bytes32 _feeType) public view returns(uint256) {
         uint256 fee;
-        bytes memory callData = abi.encodeWithSignature("getFee()");
         address feeManager = feeManagerContract();
+        string memory method = _feeType == HOME_FEE ? "getHomeFee()" : "getForeignFee()";
+        bytes memory callData = abi.encodeWithSignature(method);
+
         assembly {
             let result := callcode(gas, feeManager, 0x0, add(callData, 0x20), mload(callData), 0, 32)
             fee := mload(0)
@@ -46,8 +61,9 @@ contract RewardableBridge is Ownable {
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
     }
 
-    function _setFee(address _feeManager, uint256 _fee) internal {
-        require(_feeManager.delegatecall(abi.encodeWithSignature("setFee(uint256)", _fee)));
+    function _setFee(address _feeManager, uint256 _fee, bytes32 _feeType) internal {
+        string memory method = _feeType == HOME_FEE ? "setHomeFee(uint256)" : "setForeignFee(uint256)";
+        require(_feeManager.delegatecall(abi.encodeWithSignature(method, _fee)));
     }
 
     function isContract(address _addr) internal view returns (bool)
@@ -57,9 +73,9 @@ contract RewardableBridge is Ownable {
         return length > 0;
     }
 
-    function calculateFee(uint256 _value, bool _recover, address _impl) internal view returns(uint256) {
+    function calculateFee(uint256 _value, bool _recover, address _impl, bytes32 _feeType) internal view returns(uint256) {
         uint256 fee;
-        bytes memory callData = abi.encodeWithSignature("calculateFee(uint256,bool)", _value, _recover);
+        bytes memory callData = abi.encodeWithSignature("calculateFee(uint256,bool,bytes32)", _value, _recover, _feeType);
         assembly {
             let result := callcode(gas, _impl, 0x0, add(callData, 0x20), mload(callData), 0, 32)
             fee := mload(0)

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -8,10 +8,10 @@ import "../../ERC677Receiver.sol";
 import "../BasicHomeBridge.sol";
 import "../ERC677Bridge.sol";
 import "../OverdrawManagement.sol";
-import "../RewardableBridge.sol";
+import "./RewardableHomeBridgeErcToNative.sol";
 
 
-contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, OverdrawManagement, RewardableBridge {
+contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, OverdrawManagement, RewardableHomeBridgeErcToNative {
 
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -26,7 +26,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         uint256 valueToTransfer = msg.value;
         address feeManager = feeManagerContract();
         if (feeManager != address(0)) {
-            uint256 fee = calculateFee(valueToTransfer, false, feeManager);
+            uint256 fee = calculateFee(valueToTransfer, false, feeManager, HOME_FEE);
             valueToTransfer = valueToTransfer.sub(fee);
         }
         setTotalBurntCoins(totalBurntCoins().add(valueToTransfer));
@@ -76,7 +76,8 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         uint256 _foreignMaxPerTx,
         address _owner,
         address _feeManager,
-        uint256 _fee
+        uint256 _homeFee,
+        uint256 _foreignFee
     ) public returns(bool)
     {
         _initialize(
@@ -93,7 +94,8 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         );
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
-        _setFee(_feeManager, _fee);
+        _setFee(_feeManager, _homeFee, HOME_FEE);
+        _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize(true);
 
         return isInitialized();
@@ -157,7 +159,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
 
         address feeManager = feeManagerContract();
         if (feeManager != address(0)) {
-            uint256 fee = calculateFee(valueToMint, false, feeManager);
+            uint256 fee = calculateFee(valueToMint, false, feeManager, FOREIGN_FEE);
             distributeFeeFromAffirmation(fee, feeManager);
             valueToMint = valueToMint.sub(fee);
         }
@@ -173,7 +175,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
             bytes32 txHash;
             address contractAddress;
             (recipient, amount, txHash, contractAddress) = Message.parseMessage(_message);
-            uint256 fee = calculateFee(amount, true, feeManager);
+            uint256 fee = calculateFee(amount, true, feeManager, HOME_FEE);
             distributeFeeFromSignatures(fee, feeManager);
         }
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.4.24;
+
+import "../RewardableBridge.sol";
+
+
+contract RewardableHomeBridgeErcToNative is RewardableBridge {
+
+    function setHomeFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, HOME_FEE);
+    }
+
+    function setForeignFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
+    }
+
+    function getHomeFee() public view returns(uint256) {
+        return _getFee(HOME_FEE);
+    }
+
+    function getForeignFee() public view returns(uint256) {
+        return _getFee(FOREIGN_FEE);
+    }
+}

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -6,10 +6,10 @@ import "../../ERC677Receiver.sol";
 import "../BasicForeignBridge.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "../ERC677Bridge.sol";
-import "../RewardableBridge.sol";
+import "./RewardableForeignBridgeNativeToErc.sol";
 
 
-contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBridge, ERC677Bridge, RewardableBridge {
+contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBridge, ERC677Bridge, RewardableForeignBridgeNativeToErc {
 
     /// Event created on money withdraw.
     event UserRequestForAffirmation(address recipient, uint256 value);

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -54,7 +54,8 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         uint256 _homeMaxPerTx,
         address _owner,
         address _feeManager,
-        uint256 _fee
+        uint256 _homeFee,
+        uint256 _foreignFee
     ) public returns(bool) {
         _initialize(
             _validatorContract,
@@ -70,7 +71,8 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         );
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
-        _setFee(_feeManager, _fee);
+        _setFee(_feeManager, _homeFee, HOME_FEE);
+        _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize(true);
         return isInitialized();
     }
@@ -119,7 +121,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         uint256 valueToMint = _amount;
         address feeManager = feeManagerContract();
         if (feeManager != address(0)) {
-            uint256 fee = calculateFee(valueToMint, false, feeManager);
+            uint256 fee = calculateFee(valueToMint, false, feeManager, HOME_FEE);
             distributeFeeFromSignatures(fee, feeManager);
             valueToMint = valueToMint.sub(fee);
         }

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -54,8 +54,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         uint256 _homeMaxPerTx,
         address _owner,
         address _feeManager,
-        uint256 _homeFee,
-        uint256 _foreignFee
+        uint256 _homeFee
     ) public returns(bool) {
         _initialize(
             _validatorContract,
@@ -72,7 +71,6 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
-        _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize(true);
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -4,11 +4,11 @@ import "../../libraries/Message.sol";
 import "../BasicBridge.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../BasicHomeBridge.sol";
-import "../RewardableBridge.sol";
+import "./RewardableHomeBridgeNativeToErc.sol";
 import "../Sacrifice.sol";
 
 
-contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, RewardableBridge {
+contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
 
     function () public payable {
         require(msg.value > 0);

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -56,7 +56,6 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
         uint256 _foreignMaxPerTx,
         address _owner,
         address _feeManager,
-        uint256 _homeFee,
         uint256 _foreignFee
     ) public returns(bool)
     {
@@ -73,7 +72,6 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
         );
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
-        _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize(true);
         return isInitialized();

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -56,7 +56,8 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
         uint256 _foreignMaxPerTx,
         address _owner,
         address _feeManager,
-        uint256 _fee
+        uint256 _homeFee,
+        uint256 _foreignFee
     ) public returns(bool)
     {
         _initialize(
@@ -72,7 +73,8 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
         );
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
-        _setFee(_feeManager, _fee);
+        _setFee(_feeManager, _homeFee, HOME_FEE);
+        _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize(true);
         return isInitialized();
     }
@@ -118,7 +120,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
 
         address feeManager = feeManagerContract();
         if (feeManager != address(0)) {
-            uint256 fee = calculateFee(valueToTransfer, false, feeManager);
+            uint256 fee = calculateFee(valueToTransfer, false, feeManager, FOREIGN_FEE);
             distributeFeeFromAffirmation(fee, feeManager);
             valueToTransfer = valueToTransfer.sub(fee);
         }

--- a/contracts/upgradeable_contracts/native_to_erc20/RewardableForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/RewardableForeignBridgeNativeToErc.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.4.24;
+
+import "../RewardableBridge.sol";
+
+
+contract RewardableForeignBridgeNativeToErc is RewardableBridge {
+
+    function setHomeFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, HOME_FEE);
+    }
+
+    function getHomeFee() public view returns(uint256) {
+        return _getFee(HOME_FEE);
+    }
+}

--- a/contracts/upgradeable_contracts/native_to_erc20/RewardableHomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/RewardableHomeBridgeNativeToErc.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.4.24;
+
+import "../RewardableBridge.sol";
+
+
+contract RewardableHomeBridgeNativeToErc is RewardableBridge {
+
+    function setForeignFee(uint256 _fee) external onlyOwner {
+        _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
+    }
+
+    function getForeignFee() public view returns(uint256) {
+        return _getFee(FOREIGN_FEE);
+    }
+}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -48,10 +48,10 @@ FOREIGN_REWARDABLE=false
 #E.g. VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 VALIDATORS_REWARD_ACCOUNTS=0x
 
-# Fee to be charged for each transfer on Home:
+# Fee to be taken for every transaction directed from the Home network to the Foreign network
 # E.g. 0.1% fee
 HOME_TRANSACTIONS_FEE=0.001
-# Fee to be charged for each transfer on Foreign:
+# Fee to be taken for every transaction directed from the Foreign network to the Home network
 FOREIGN_TRANSACTIONS_FEE=0.001
 #for bridge native_to_erc mode
 DEPLOY_REWARDABLE_TOKEN=false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -132,12 +132,12 @@ FOREIGN_REWARDABLE=false
 # Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
 VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 
-# Fee to be charged for each transfer on Home network
-# Makes sense only when HOME_REWARDABLE=true
+# Fee to be taken for every transaction directed from the Home network to the Foreign network
+# Makes sense only when FOREIGN_REWARDABLE=true
 # e.g. 0.1% fee
 HOME_TRANSACTIONS_FEE=0.001
-# Fee to be charged for each transfer on Foreign network
-# Makes sense only when FOREIGN_REWARDABLE=true
+# Fee to be taken for every transaction directed from the Foreign network to the Home network
+# Makes sense only when HOME_REWARDABLE=true
 # e.g. 0.1% fee
 FOREIGN_TRANSACTIONS_FEE=0.001
 
@@ -355,12 +355,12 @@ FOREIGN_REWARDABLE=false
 # Makes sense only when HOME_REWARDABLE=true or FOREIGN_REWARDABLE=true
 VALIDATORS_REWARD_ACCOUNTS=0x 0x 0x
 
-# Fee to be charged for each transfer on Home network
+# Fee to be taken for every transaction directed from the Home network to the Foreign network
 # Makes sense only when HOME_REWARDABLE=true
 # e.g. 0.1% fee
 HOME_TRANSACTIONS_FEE=0.001
-# Fee to be charged for each transfer on Foreign network
-# Makes sense only when FOREIGN_REWARDABLE=true
+# Fee to be taken for every transaction directed from the Foreign network to the Home network
+# Makes sense only when HOME_REWARDABLE=true
 # e.g. 0.1% fee
 FOREIGN_TRANSACTIONS_FEE=0.001
 ```

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -190,7 +190,7 @@ async function deployHome() {
   HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
   Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
-  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
+  Foreign Fee: ${foreignFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
     initializeHomeBridgeData = await homeBridgeImplementation.methods
       .rewardableInitialize(
         storageValidatorsHome.options.address,

--- a/deploy/src/erc_to_native/home.js
+++ b/deploy/src/erc_to_native/home.js
@@ -34,7 +34,8 @@ const {
   FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
   HOME_REWARDABLE,
-  HOME_TRANSACTIONS_FEE
+  HOME_TRANSACTIONS_FEE,
+  FOREIGN_TRANSACTIONS_FEE
 } = env
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
@@ -167,7 +168,8 @@ async function deployHome() {
     console.log('[Home] feeManager Implementation: ', feeManager.options.address)
     homeNonce++
 
-    const feeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
+    const homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
+    const foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
     console.log('\ninitializing Home Bridge with fee contract:\n')
     console.log(`Home Validators: ${storageValidatorsHome.options.address},
   HOME_DAILY_LIMIT : ${HOME_DAILY_LIMIT} which is ${Web3Utils.fromWei(HOME_DAILY_LIMIT)} in eth,
@@ -187,7 +189,8 @@ async function deployHome() {
     )} in eth,
   HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
-  Fee: ${feeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%`)
+  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
+  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
     initializeHomeBridgeData = await homeBridgeImplementation.methods
       .rewardableInitialize(
         storageValidatorsHome.options.address,
@@ -201,7 +204,8 @@ async function deployHome() {
         FOREIGN_MAX_AMOUNT_PER_TX,
         HOME_BRIDGE_OWNER,
         feeManager.options.address,
-        feeInWei
+        homeFeeInWei,
+        foreignFeeInWei
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   } else {

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -114,20 +114,12 @@ if (BRIDGE_MODE === 'ERC_TO_NATIVE') {
   }
 }
 
-if (HOME_REWARDABLE === 'true') {
+if (HOME_REWARDABLE === 'true' || FOREIGN_REWARDABLE === 'true') {
   validateRewardableAddresses(VALIDATORS, VALIDATORS_REWARD_ACCOUNTS)
   validations = {
     ...validations,
     VALIDATORS_REWARD_ACCOUNTS: addressesValidator(),
-    HOME_TRANSACTIONS_FEE: envalid.num()
-  }
-}
-
-if (FOREIGN_REWARDABLE === 'true') {
-  validateRewardableAddresses(VALIDATORS, VALIDATORS_REWARD_ACCOUNTS)
-  validations = {
-    ...validations,
-    VALIDATORS_REWARD_ACCOUNTS: addressesValidator(),
+    HOME_TRANSACTIONS_FEE: envalid.num(),
     FOREIGN_TRANSACTIONS_FEE: envalid.num()
   }
 }

--- a/deploy/src/native_to_erc/foreign.js
+++ b/deploy/src/native_to_erc/foreign.js
@@ -41,8 +41,7 @@ const {
   BLOCK_REWARD_ADDRESS,
   DPOS_VALIDATOR_SET_ADDRESS,
   FOREIGN_REWARDABLE,
-  HOME_TRANSACTIONS_FEE,
-  FOREIGN_TRANSACTIONS_FEE
+  HOME_TRANSACTIONS_FEE
 } = env
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
@@ -212,7 +211,6 @@ async function deployForeign() {
     foreignNonce++
 
     const homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
-    const foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
 
     console.log('\ninitializing Foreign Bridge with fee contract:\n')
     console.log(`Foreign Validators: ${storageValidatorsForeign.options.address},
@@ -232,8 +230,7 @@ async function deployForeign() {
     )} in eth,
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
-  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
-  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
+  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%`)
 
     initializeFBridgeData = await foreignBridgeImplementation.methods
       .rewardableInitialize(
@@ -248,8 +245,7 @@ async function deployForeign() {
         HOME_MAX_AMOUNT_PER_TX,
         FOREIGN_BRIDGE_OWNER,
         feeManager.options.address,
-        homeFeeInWei,
-        foreignFeeInWei
+        homeFeeInWei
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   } else {

--- a/deploy/src/native_to_erc/foreign.js
+++ b/deploy/src/native_to_erc/foreign.js
@@ -41,6 +41,7 @@ const {
   BLOCK_REWARD_ADDRESS,
   DPOS_VALIDATOR_SET_ADDRESS,
   FOREIGN_REWARDABLE,
+  HOME_TRANSACTIONS_FEE,
   FOREIGN_TRANSACTIONS_FEE
 } = env
 
@@ -210,7 +211,8 @@ async function deployForeign() {
     console.log('[Foreign] feeManager Implementation: ', feeManager.options.address)
     foreignNonce++
 
-    const feeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
+    const homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
+    const foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
 
     console.log('\ninitializing Foreign Bridge with fee contract:\n')
     console.log(`Foreign Validators: ${storageValidatorsForeign.options.address},
@@ -230,7 +232,8 @@ async function deployForeign() {
     )} in eth,
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
-  Fee: ${feeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
+  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
+  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
 
     initializeFBridgeData = await foreignBridgeImplementation.methods
       .rewardableInitialize(
@@ -245,7 +248,8 @@ async function deployForeign() {
         HOME_MAX_AMOUNT_PER_TX,
         FOREIGN_BRIDGE_OWNER,
         feeManager.options.address,
-        feeInWei
+        homeFeeInWei,
+        foreignFeeInWei
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   } else {

--- a/deploy/src/native_to_erc/home.js
+++ b/deploy/src/native_to_erc/home.js
@@ -33,7 +33,6 @@ const {
   FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
   HOME_REWARDABLE,
-  HOME_TRANSACTIONS_FEE,
   FOREIGN_TRANSACTIONS_FEE
 } = env
 
@@ -167,7 +166,6 @@ async function deployHome() {
     console.log('[Home] feeManager Implementation: ', feeManager.options.address)
     homeNonce++
 
-    const homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
     const foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
 
     console.log('\ninitializing Home Bridge with fee contract:\n')
@@ -188,8 +186,7 @@ async function deployHome() {
     )} in eth,
   HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
-  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
-  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
+  Foreign Fee: ${foreignFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
 
     homeBridgeImplementation.options.address = homeBridgeStorage.options.address
     initializeHomeBridgeData = await homeBridgeImplementation.methods
@@ -204,7 +201,6 @@ async function deployHome() {
         FOREIGN_MAX_AMOUNT_PER_TX,
         HOME_BRIDGE_OWNER,
         feeManager.options.address,
-        homeFeeInWei,
         foreignFeeInWei
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })

--- a/deploy/src/native_to_erc/home.js
+++ b/deploy/src/native_to_erc/home.js
@@ -33,7 +33,8 @@ const {
   FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
   HOME_REWARDABLE,
-  HOME_TRANSACTIONS_FEE
+  HOME_TRANSACTIONS_FEE,
+  FOREIGN_TRANSACTIONS_FEE
 } = env
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
@@ -166,7 +167,8 @@ async function deployHome() {
     console.log('[Home] feeManager Implementation: ', feeManager.options.address)
     homeNonce++
 
-    const feeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
+    const homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
+    const foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
 
     console.log('\ninitializing Home Bridge with fee contract:\n')
     console.log(`Home Validators: ${storageValidatorsHome.options.address},
@@ -186,7 +188,8 @@ async function deployHome() {
     )} in eth,
   HOME_BRIDGE_OWNER: ${HOME_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
-  Fee: ${feeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%`)
+  Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%
+  Foreign Fee: ${homeFeeInWei} which is ${FOREIGN_TRANSACTIONS_FEE * 100}%`)
 
     homeBridgeImplementation.options.address = homeBridgeStorage.options.address
     initializeHomeBridgeData = await homeBridgeImplementation.methods
@@ -201,7 +204,8 @@ async function deployHome() {
         FOREIGN_MAX_AMOUNT_PER_TX,
         HOME_BRIDGE_OWNER,
         feeManager.options.address,
-        feeInWei
+        homeFeeInWei,
+        foreignFeeInWei
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   } else {

--- a/docs/ERC-TO-NATIVE-WITH-REWARD.md
+++ b/docs/ERC-TO-NATIVE-WITH-REWARD.md
@@ -10,12 +10,12 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeErcToNative|deployment|5653534|5653534|5653534
+HomeBridgeErcToNative|deployment|5644337|5644337|5644337
 EternalStorageProxy|upgradeTo|35871|30924|30913
 FeeManagerErcToNative|deployment|1068197|1068197|1068197
 HomeBridgeErcToNative|rewardableInitialize|353084|353148|353132
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |9783384|9994135|9888813
+Total| |9774187|9984938|9879616
 
 ##### Foreign
  Contract | Method | Min | Max | Avg

--- a/docs/ERC-TO-NATIVE-WITH-REWARD.md
+++ b/docs/ERC-TO-NATIVE-WITH-REWARD.md
@@ -10,12 +10,12 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeErcToNative|deployment|5088498|5088498|5088498
+HomeBridgeErcToNative|deployment|5653534|5653534|5653534
 EternalStorageProxy|upgradeTo|35871|30924|30913
-FeeManagerErcToNative|deployment|849694|849694|849694
-HomeBridgeErcToNative|rewardableInitialize|327113|327177|327161
+FeeManagerErcToNative|deployment|1068197|1068197|1068197
+HomeBridgeErcToNative|rewardableInitialize|353084|353148|353132
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8973874|9184625|9079303
+Total| |9783384|9994135|9888813
 
 ##### Foreign
  Contract | Method | Min | Max | Avg

--- a/docs/ERC-TO-NATIVE.md
+++ b/docs/ERC-TO-NATIVE.md
@@ -10,11 +10,11 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeErcToNative|deployment|5088498|5088498|5088498
+HomeBridgeErcToNative|deployment|5653534|5653534|5653534
 EternalStorageProxy|upgradeTo|35871|30924|30913
 HomeBridgeErcToNative|initialize|264356|281376|278561
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |7805175|7908146|7869602
+Total| |8370211|8473182|8434638
 
 ##### Foreign
  Contract | Method | Min | Max | Avg

--- a/docs/ERC-TO-NATIVE.md
+++ b/docs/ERC-TO-NATIVE.md
@@ -10,11 +10,11 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeErcToNative|deployment|5653534|5653534|5653534
+HomeBridgeErcToNative|deployment|5644337|5644337|5644337
 EternalStorageProxy|upgradeTo|35871|30924|30913
 HomeBridgeErcToNative|initialize|264356|281376|278561
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8370211|8473182|8434638
+Total| |8361014|8463985|8425441
 
 ##### Foreign
  Contract | Method | Min | Max | Avg

--- a/docs/NATIVE-TO-ERC-WITH-REWARD.md
+++ b/docs/NATIVE-TO-ERC-WITH-REWARD.md
@@ -10,12 +10,12 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeNativeToErc|deployment|4709570|4709570|4709570
+HomeBridgeNativeToErc|deployment|4594464|4594464|4594464
 EternalStorageProxy|upgradeTo|35871|30924|30913
 FeeManagerNativeToErc|deployment|1079956|1079956|1079956
-HomeBridgeNativeToErc|rewardableInitialize|330597|330725|330679
+HomeBridgeNativeToErc|rewardableInitialize|306629|306693|306647
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8828692|9039507|8934155
+Total| |8689618|8900369|8795017
 
 ##### Foreign
  Contract | Method | Min | Max | Avg
@@ -27,14 +27,14 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-ForeignBridgeNativeToErc|deployment|4056029|4056029|4056029
+ForeignBridgeNativeToErc|deployment|3930131|3930131|3930131
 EternalStorageProxy|upgradeTo|35871|30924|30913
 FeeManagerNativeToErc|deployment|1079956|1079956|1079956
-ForeignBridgeNativeToErc|rewardableInitialize|354062|354126|354080
+ForeignBridgeNativeToErc|rewardableInitialize|329022|329086|329077
 ERC677BridgeToken|setBridgeContract|29432|44432|39432
 ERC677BridgeToken|transferOwnership|30860|30924|30913
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |9722444|9949283|9838530
+Total| |9571506|9798345|9687629
 
 #### Usage
 

--- a/docs/NATIVE-TO-ERC-WITH-REWARD.md
+++ b/docs/NATIVE-TO-ERC-WITH-REWARD.md
@@ -10,12 +10,12 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeNativeToErc|deployment|4193535|4193535|4193535
+HomeBridgeNativeToErc|deployment|4709570|4709570|4709570
 EternalStorageProxy|upgradeTo|35871|30924|30913
-FeeManagerNativeToErc|deployment|861773|861773|861773
-HomeBridgeNativeToErc|rewardableInitialize|305520|305584|305563
+FeeManagerNativeToErc|deployment|1079956|1079956|1079956
+HomeBridgeNativeToErc|rewardableInitialize|330597|330725|330679
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8069397|8280148|8174821
+Total| |8828692|9039507|8934155
 
 ##### Foreign
  Contract | Method | Min | Max | Avg
@@ -27,14 +27,14 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 RewardableValidators|initialize|202711|423292|318008
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-ForeignBridgeNativeToErc|deployment|3534781|3534781|3534781
+ForeignBridgeNativeToErc|deployment|4056029|4056029|4056029
 EternalStorageProxy|upgradeTo|35871|30924|30913
-FeeManagerNativeToErc|deployment|861773|861773|861773
-ForeignBridgeNativeToErc|rewardableInitialize|327843|327907|327896
+FeeManagerNativeToErc|deployment|1079956|1079956|1079956
+ForeignBridgeNativeToErc|rewardableInitialize|354062|354126|354080
 ERC677BridgeToken|setBridgeContract|29432|44432|39432
 ERC677BridgeToken|transferOwnership|30860|30924|30913
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8956794|9183633|9072915
+Total| |9722444|9949283|9838530
 
 #### Usage
 

--- a/docs/NATIVE-TO-ERC.md
+++ b/docs/NATIVE-TO-ERC.md
@@ -10,11 +10,11 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeNativeToErc|deployment|4193535|4193535|4193535
+HomeBridgeNativeToErc|deployment|4709570|4709570|4709570
 EternalStorageProxy|upgradeTo|35871|30924|30913
 HomeBridgeNativeToErc|initialize|257416|258312|258003
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |6903272|6990119|6954081
+Total| |7419307|7506154|7470116
 
 ##### Foreign
  Contract | Method | Min | Max | Avg
@@ -26,13 +26,13 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-ForeignBridgeNativeToErc|deployment|3534781|3534781|3534781
+ForeignBridgeNativeToErc|deployment|4056029|4056029|4056029
 EternalStorageProxy|upgradeTo|35871|30924|30913
 ForeignBridgeNativeToErc|initialize|281275|281339|281328
 ERC677BridgeToken|setBridgeContract|29432|44432|39432
 ERC677BridgeToken|transferOwnership|30860|30924|30913
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |7792205|7894308|7853167
+Total| |8313453|8415556|8374415
 
 #### Usage
 

--- a/docs/NATIVE-TO-ERC.md
+++ b/docs/NATIVE-TO-ERC.md
@@ -10,11 +10,11 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-HomeBridgeNativeToErc|deployment|4709570|4709570|4709570
+HomeBridgeNativeToErc|deployment|4594464|4594464|4594464
 EternalStorageProxy|upgradeTo|35871|30924|30913
 HomeBridgeNativeToErc|initialize|257416|258312|258003
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |7419307|7506154|7470116
+Total| |7304201|7391048|7355010
 
 ##### Foreign
  Contract | Method | Min | Max | Avg
@@ -26,13 +26,13 @@ EternalStorageProxy|upgradeTo|35871|30924|30913
 BridgeValidators|initialize|210762|306607|270900
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
 EternalStorageProxy|deployment|378510|378510|378510
-ForeignBridgeNativeToErc|deployment|4056029|4056029|4056029
+ForeignBridgeNativeToErc|deployment|3930131|3930131|3930131
 EternalStorageProxy|upgradeTo|35871|30924|30913
 ForeignBridgeNativeToErc|initialize|281275|281339|281328
 ERC677BridgeToken|setBridgeContract|29432|44432|39432
 ERC677BridgeToken|transferOwnership|30860|30924|30913
 EternalStorageProxy|transferProxyOwnership|30653|30653|30653
-Total| |8313453|8415556|8374415
+Total| |8187555|8289658|8248517
 
 #### Usage
 

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -514,7 +514,7 @@ contract('ForeignBridge', async (accounts) => {
   })
 
   describe('#rewardableInitialize', async() => {
-    let homeFee, foreignFee, foreignBridge, token, rewardableValidators
+    let homeFee, foreignBridge, token, rewardableValidators
     let validators = [accounts[1]]
     let rewards = [accounts[2]]
     let requiredSignatures = 1
@@ -524,7 +524,6 @@ contract('ForeignBridge', async (accounts) => {
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
       foreignBridge =  await ForeignBridge.new()
       homeFee = web3.toBigNumber(web3.toWei(0.001, "ether"))
-      foreignFee = web3.toBigNumber(web3.toWei(0.002, "ether"))
     })
     it('sets variables', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
@@ -534,13 +533,13 @@ contract('ForeignBridge', async (accounts) => {
       '0'.should.be.bignumber.equal(await foreignBridge.maxPerTx())
       false.should.be.equal(await foreignBridge.isInitialized())
 
-      await foreignBridge.rewardableInitialize(ZERO_ADDRESS, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(owner, token.address, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, ZERO_ADDRESS, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(ZERO_ADDRESS, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(owner, token.address, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, ZERO_ADDRESS, homeFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.fulfilled;
 
       true.should.be.equal(await foreignBridge.isInitialized())
       rewardableValidators.address.should.be.equal(await foreignBridge.validatorContract());
@@ -564,7 +563,7 @@ contract('ForeignBridge', async (accounts) => {
 
     it('can update fee contract', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.fulfilled;
 
       // Given
       const newFeeManager = await FeeManagerNativeToErc.new()
@@ -579,7 +578,7 @@ contract('ForeignBridge', async (accounts) => {
 
     it('can update fee', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.fulfilled;
 
       // Given
       const newHomeFee = web3.toBigNumber(web3.toWei(0.1, "ether"))
@@ -598,7 +597,7 @@ contract('ForeignBridge', async (accounts) => {
       const oneDirectionsModeHash = '0xf2aed8f7'
 
       // When
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee).should.be.fulfilled;
 
       // Then
       const feeManagerMode = await foreignBridge.getFeeManagerMode()
@@ -617,7 +616,6 @@ contract('ForeignBridge', async (accounts) => {
     it('should distribute fee to validator', async () => {
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const value = halfEther
       const finalUserValue = value.mul(web3.toBigNumber(1-fee));
       const feeAmount = value.mul(web3.toBigNumber(fee))
@@ -626,7 +624,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[2]]
       const requiredSignatures = 1
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[3];
@@ -656,7 +654,6 @@ contract('ForeignBridge', async (accounts) => {
       // Given
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const feePerValidator = web3.toBigNumber(166666666666666)
       const feePerValidatorPlusDiff = web3.toBigNumber(166666666666668)
       const value = halfEther
@@ -666,7 +663,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[4], accounts[5], accounts[6]]
       const requiredSignatures = 3
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[7];
@@ -718,7 +715,6 @@ contract('ForeignBridge', async (accounts) => {
       // Given
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const value = halfEther
       const feeAmount = value.mul(web3.toBigNumber(fee))
       const feePerValidator = feeAmount.div(web3.toBigNumber(5))
@@ -728,7 +724,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[5], accounts[6], accounts[7], accounts[8], accounts[9]]
       const requiredSignatures = 3
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[0];

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -560,8 +560,6 @@ contract('ForeignBridge', async (accounts) => {
       feeManagerContract.should.be.equals(feeManager.address)
       const bridgeHomeFee = await foreignBridge.getHomeFee()
       bridgeHomeFee.should.be.bignumber.equal(homeFee)
-      const bridgeForeignFee = await foreignBridge.getForeignFee()
-      bridgeForeignFee.should.be.bignumber.equal(foreignFee)
     })
 
     it('can update fee contract', async () => {
@@ -585,17 +583,13 @@ contract('ForeignBridge', async (accounts) => {
 
       // Given
       const newHomeFee = web3.toBigNumber(web3.toWei(0.1, "ether"))
-      const newForeignFee = web3.toBigNumber(web3.toWei(0.2, "ether"))
 
       // When
       await foreignBridge.setHomeFee(newHomeFee, { from: owner }).should.be.fulfilled
-      await foreignBridge.setForeignFee(newForeignFee, { from: owner }).should.be.fulfilled
 
       // Then
       const bridgeHomeFee = await foreignBridge.getHomeFee()
       bridgeHomeFee.should.be.bignumber.equal(newHomeFee)
-      const bridgeForeignFee = await foreignBridge.getForeignFee()
-      bridgeForeignFee.should.be.bignumber.equal(newForeignFee)
     })
 
     it('should be able to get fee manager mode', async () => {

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -514,7 +514,7 @@ contract('ForeignBridge', async (accounts) => {
   })
 
   describe('#rewardableInitialize', async() => {
-    let fee, foreignBridge, token, rewardableValidators
+    let homeFee, foreignFee, foreignBridge, token, rewardableValidators
     let validators = [accounts[1]]
     let rewards = [accounts[2]]
     let requiredSignatures = 1
@@ -523,7 +523,8 @@ contract('ForeignBridge', async (accounts) => {
       rewardableValidators = await RewardableValidators.new()
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
       foreignBridge =  await ForeignBridge.new()
-      fee = web3.toBigNumber(web3.toWei(0.001, "ether"))
+      homeFee = web3.toBigNumber(web3.toWei(0.001, "ether"))
+      foreignFee = web3.toBigNumber(web3.toWei(0.002, "ether"))
     })
     it('sets variables', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
@@ -533,13 +534,13 @@ contract('ForeignBridge', async (accounts) => {
       '0'.should.be.bignumber.equal(await foreignBridge.maxPerTx())
       false.should.be.equal(await foreignBridge.isInitialized())
 
-      await foreignBridge.rewardableInitialize(ZERO_ADDRESS, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(owner, token.address, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, ZERO_ADDRESS, fee).should.be.rejectedWith(ERROR_MSG);
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(ZERO_ADDRESS, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(owner, token.address, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, owner, oneEther, halfEther, minPerTx, requireBlockConfirmations, gasPrice, homeDailyLimit, homeMaxPerTx, owner, ZERO_ADDRESS, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
 
       true.should.be.equal(await foreignBridge.isInitialized())
       rewardableValidators.address.should.be.equal(await foreignBridge.validatorContract());
@@ -557,13 +558,15 @@ contract('ForeignBridge', async (accounts) => {
 
       const feeManagerContract = await foreignBridge.feeManagerContract()
       feeManagerContract.should.be.equals(feeManager.address)
-      const bridgeFee = await foreignBridge.getFee()
-      bridgeFee.should.be.bignumber.equal(fee)
+      const bridgeHomeFee = await foreignBridge.getHomeFee()
+      bridgeHomeFee.should.be.bignumber.equal(homeFee)
+      const bridgeForeignFee = await foreignBridge.getForeignFee()
+      bridgeForeignFee.should.be.bignumber.equal(foreignFee)
     })
 
     it('can update fee contract', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
 
       // Given
       const newFeeManager = await FeeManagerNativeToErc.new()
@@ -578,17 +581,21 @@ contract('ForeignBridge', async (accounts) => {
 
     it('can update fee', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
 
       // Given
-      const newFee = web3.toBigNumber(web3.toWei(0.1, "ether"))
+      const newHomeFee = web3.toBigNumber(web3.toWei(0.1, "ether"))
+      const newForeignFee = web3.toBigNumber(web3.toWei(0.2, "ether"))
 
       // When
-      await foreignBridge.setFee(newFee, { from: owner }).should.be.fulfilled
+      await foreignBridge.setHomeFee(newHomeFee, { from: owner }).should.be.fulfilled
+      await foreignBridge.setForeignFee(newForeignFee, { from: owner }).should.be.fulfilled
 
       // Then
-      const bridgeFee = await foreignBridge.getFee()
-      bridgeFee.should.be.bignumber.equal(newFee)
+      const bridgeHomeFee = await foreignBridge.getHomeFee()
+      bridgeHomeFee.should.be.bignumber.equal(newHomeFee)
+      const bridgeForeignFee = await foreignBridge.getForeignFee()
+      bridgeForeignFee.should.be.bignumber.equal(newForeignFee)
     })
 
     it('should be able to get fee manager mode', async () => {
@@ -597,7 +604,7 @@ contract('ForeignBridge', async (accounts) => {
       const oneDirectionsModeHash = '0xf2aed8f7'
 
       // When
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, fee).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
 
       // Then
       const feeManagerMode = await foreignBridge.getFeeManagerMode()
@@ -616,6 +623,7 @@ contract('ForeignBridge', async (accounts) => {
     it('should distribute fee to validator', async () => {
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
+      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const value = halfEther
       const finalUserValue = value.mul(web3.toBigNumber(1-fee));
       const feeAmount = value.mul(web3.toBigNumber(fee))
@@ -624,7 +632,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[2]]
       const requiredSignatures = 1
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[3];
@@ -654,6 +662,7 @@ contract('ForeignBridge', async (accounts) => {
       // Given
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
+      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const feePerValidator = web3.toBigNumber(166666666666666)
       const feePerValidatorPlusDiff = web3.toBigNumber(166666666666668)
       const value = halfEther
@@ -663,7 +672,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[4], accounts[5], accounts[6]]
       const requiredSignatures = 3
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[7];
@@ -715,6 +724,7 @@ contract('ForeignBridge', async (accounts) => {
       // Given
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
+      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const value = halfEther
       const feeAmount = value.mul(web3.toBigNumber(fee))
       const feePerValidator = feeAmount.div(web3.toBigNumber(5))
@@ -724,7 +734,7 @@ contract('ForeignBridge', async (accounts) => {
       const rewards = [accounts[5], accounts[6], accounts[7], accounts[8], accounts[9]]
       const requiredSignatures = 3
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
-      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
+      await foreignBridge.rewardableInitialize(rewardableValidators.address, token.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, homeDailyLimit, homeMaxPerTx, owner, feeManager.address, feeInWei, feeNotUsedInWei).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address);
 
       const recipientAccount = accounts[0];

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -558,7 +558,7 @@ contract('HomeBridge', async (accounts) => {
   })
 
   describe('#rewardableInitialize', async() => {
-    let homeFee, foreignFee, homeBridge, rewardableValidators
+    let foreignFee, homeBridge, rewardableValidators
     let validators = [accounts[1]]
     let rewards = [accounts[2]]
     let requiredSignatures = 1
@@ -566,7 +566,6 @@ contract('HomeBridge', async (accounts) => {
       rewardableValidators = await RewardableValidators.new()
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
       homeBridge =  await HomeBridge.new()
-      homeFee = web3.toBigNumber(web3.toWei(0.001, "ether"))
       foreignFee = web3.toBigNumber(web3.toWei(0.002, "ether"))
     })
     it('sets variables', async () => {
@@ -577,11 +576,11 @@ contract('HomeBridge', async (accounts) => {
       '0'.should.be.bignumber.equal(await homeBridge.maxPerTx())
       false.should.be.equal(await homeBridge.isInitialized())
 
-      await homeBridge.rewardableInitialize(ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, 0, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, ZERO_ADDRESS, homeFee, foreignFee).should.be.rejectedWith(ERROR_MSG);
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(ZERO_ADDRESS, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, 0, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, 0, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, ZERO_ADDRESS, foreignFee).should.be.rejectedWith(ERROR_MSG);
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.fulfilled;
 
       true.should.be.equal(await homeBridge.isInitialized())
       rewardableValidators.address.should.be.equal(await homeBridge.validatorContract());
@@ -605,7 +604,7 @@ contract('HomeBridge', async (accounts) => {
 
     it('can update fee contract', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.fulfilled;
 
       // Given
       const newFeeManager = await FeeManagerNativeToErc.new()
@@ -620,7 +619,7 @@ contract('HomeBridge', async (accounts) => {
 
     it('can update fee', async () => {
       const feeManager = await FeeManagerNativeToErc.new()
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.fulfilled;
 
       // Given
       const newForeignFee = web3.toBigNumber(web3.toWei(0.2, "ether"))
@@ -638,7 +637,7 @@ contract('HomeBridge', async (accounts) => {
       const oneDirectionsModeHash = '0xf2aed8f7'
 
       // When
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, foreignFee).should.be.fulfilled;
 
       // Then
       const feeManagerMode = await homeBridge.getFeeManagerMode()
@@ -662,12 +661,11 @@ contract('HomeBridge', async (accounts) => {
       // 0.1% fee
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const value = halfEther;
       const finalUserValue = value.mul(web3.toBigNumber(1-fee));
       const feeAmount = value.mul(web3.toBigNumber(fee))
 
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeNotUsedInWei, feeInWei).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await homeBridge.sendTransaction({
         from: accounts[0],
         value: halfEther
@@ -712,7 +710,6 @@ contract('HomeBridge', async (accounts) => {
       // 0.1% fee
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const feePerValidator = web3.toBigNumber(166666666666666)
       const feePerValidatorPlusDiff = web3.toBigNumber(166666666666668)
       const finalUserValue = value.mul(web3.toBigNumber(1-fee));
@@ -720,7 +717,7 @@ contract('HomeBridge', async (accounts) => {
       const homeBridge = await HomeBridge.new()
       const feeManager = await FeeManagerNativeToErc.new()
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner, {from: owner}).should.be.fulfilled
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeNotUsedInWei, feeInWei).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await homeBridge.sendTransaction({
         from: accounts[0],
         value: halfEther
@@ -784,7 +781,6 @@ contract('HomeBridge', async (accounts) => {
       // 0.1% fee
       const fee = 0.001
       const feeInWei = web3.toBigNumber(web3.toWei(fee, "ether"))
-      const feeNotUsedInWei = web3.toBigNumber(web3.toWei(0.5, "ether"))
       const feeAmount = value.mul(web3.toBigNumber(fee))
       const feePerValidator = feeAmount.div(web3.toBigNumber(5))
 
@@ -792,7 +788,7 @@ contract('HomeBridge', async (accounts) => {
       const homeBridge = await HomeBridge.new()
       const feeManager = await FeeManagerNativeToErc.new()
       await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner, {from: owner}).should.be.fulfilled
-      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeNotUsedInWei, feeInWei).should.be.fulfilled;
+      await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, feeInWei).should.be.fulfilled;
       await homeBridge.sendTransaction({
         from: accounts[0],
         value: halfEther

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -599,8 +599,6 @@ contract('HomeBridge', async (accounts) => {
 
       const feeManagerContract = await homeBridge.feeManagerContract()
       feeManagerContract.should.be.equals(feeManager.address)
-      const bridgeHomeFee = await homeBridge.getHomeFee()
-      bridgeHomeFee.should.be.bignumber.equal(homeFee)
       const bridgeForeignFee = await homeBridge.getForeignFee()
       bridgeForeignFee.should.be.bignumber.equal(foreignFee)
     })
@@ -625,16 +623,12 @@ contract('HomeBridge', async (accounts) => {
       await homeBridge.rewardableInitialize(rewardableValidators.address, oneEther, halfEther, minPerTx, gasPrice, requireBlockConfirmations, foreignDailyLimit, foreignMaxPerTx, owner, feeManager.address, homeFee, foreignFee).should.be.fulfilled;
 
       // Given
-      const newHomeFee = web3.toBigNumber(web3.toWei(0.1, "ether"))
       const newForeignFee = web3.toBigNumber(web3.toWei(0.2, "ether"))
 
       // When
-      await homeBridge.setHomeFee(newHomeFee, { from: owner }).should.be.fulfilled
       await homeBridge.setForeignFee(newForeignFee, { from: owner }).should.be.fulfilled
 
       // Then
-      const bridgeHomeFee = await homeBridge.getHomeFee()
-      bridgeHomeFee.should.be.bignumber.equal(newHomeFee)
       const bridgeForeignFee = await homeBridge.getForeignFee()
       bridgeForeignFee.should.be.bignumber.equal(newForeignFee)
     })


### PR DESCRIPTION
Added the following methods:
- setHomeFee
- getHomeFee
- setForeignFee
- getForeignFee

I had to update `calculateFee` to receive a parameter to know which fee it should use.


> If the Fee Manager is in manages-one-direction mode (see #148) the method setFee will proxy one of the methods setHomeFee and setForeignFee depending on the side where the contract is deployed. Similar is for getFee.

Regarding this comment, I removed `setFee` and `getFee` since I couldn't find a use case for them unless I'm missing something. On bridge-ui using `getFeeManagerMode` I think it will be enough to know which fee to use.

Closes #149 