### PR TITLE
Replace poa.infura.io with core.poa.network

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -58,7 +58,7 @@ BRIDGEABLE_TOKEN_DECIMALS=18
 
 # The RPC channel to a Home node able to handle deployment/configuration
 # transactions.
-HOME_RPC_URL=https://poa.infura.io
+HOME_RPC_URL=https://core.poa.network
 # Address on Home network with permissions to change parameters of the bridge contract.
 # For extra security we recommended using a multi-sig wallet contract address here.
 HOME_BRIDGE_OWNER=0x
@@ -160,7 +160,7 @@ BRIDGEABLE_TOKEN_DECIMALS=18
 
 # The RPC channel to a Home node able to handle deployment/configuration
 # transactions.
-HOME_RPC_URL=https://poa.infura.io
+HOME_RPC_URL=https://core.poa.network
 # Address on Home network with permissions to change parameters of the bridge contract.
 # For extra security we recommended using a multi-sig wallet contract address here.
 HOME_BRIDGE_OWNER=0x
@@ -251,7 +251,7 @@ GET_RECEIPT_INTERVAL_IN_MILLISECONDS=3000
 
 # The RPC channel to a Home node able to handle deployment/configuration
 # transactions.
-HOME_RPC_URL=https://poa.infura.io
+HOME_RPC_URL=https://core.poa.network
 # Address on Home network with permissions to change parameters of the bridge contract.
 # For extra security we recommended using a multi-sig wallet contract address here.
 HOME_BRIDGE_OWNER=0x


### PR DESCRIPTION
Replace ~poa.infura.io~ with core.poa.network in README

Infura RPC endpoint for POA Core [has been disabled](https://forum.poa.network/t/infuras-poa-core-nodes-to-be-disabled-on-2-1-19/1881)