### PR TITLE
Override `transfer` and `transferFrom` in `ERC677BridgeTokenRewardable`

### DIFF
--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -63,4 +63,14 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
         emit Transfer(validatorSetContract, _staker, _amount);
     }
 
+    function transfer(address _to, uint256 _value) public returns(bool) {
+        require(_to != validatorSetContract);
+        return super.transfer(_to, _value);
+    }
+
+    function transferFrom(address _from, address _to, uint256 _value) public returns(bool) {
+        require(_to != validatorSetContract);
+        return super.transferFrom(_from, _to, _value);
+    }
+
 }

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -330,7 +330,35 @@ async function testERC677BridgeToken(accounts, rewardable) {
       await token.setBridgeContract(foreignNativeToErcBridge.address).should.be.fulfilled;
       await token.transfer(foreignNativeToErcBridge.address, lessThanMin, {from: user}).should.be.rejectedWith(ERROR_MSG);
     })
+
+    if (rewardable) {
+      it('fail to send tokens to ValidatorSet contract directly', async () => {
+        const amount = web3.toWei(1, "ether");
+        const validatorSetContractAddress = accounts[2];
+        const arbitraryAccountAddress = accounts[3];
+        await token.setValidatorSetContractMock(validatorSetContractAddress, {from: owner}).should.be.fulfilled;
+        await token.mint(user, amount, {from: owner}).should.be.fulfilled;
+        await token.transfer(validatorSetContractAddress, amount, {from: user}).should.be.rejectedWith(ERROR_MSG);
+        await token.transfer(arbitraryAccountAddress, amount, {from: user}).should.be.fulfilled;
+      });
+    }
   })
+
+  if (rewardable) {
+    describe('#transferFrom', async() => {
+      it('fail to send tokens to ValidatorSet contract directly', async () => {
+        const amount = web3.toWei(1, "ether");
+        const user2 = accounts[2];
+        const validatorSetContractAddress = accounts[3];
+        const arbitraryAccountAddress = accounts[4];
+        await token.setValidatorSetContractMock(validatorSetContractAddress, {from: owner}).should.be.fulfilled;
+        await token.mint(user, amount, {from: owner}).should.be.fulfilled;
+        await token.approve(user2, amount, {from: user}).should.be.fulfilled;
+        await token.transferFrom(user, validatorSetContractAddress, amount, {from: user2}).should.be.rejectedWith(ERROR_MSG);
+        await token.transferFrom(user, arbitraryAccountAddress, amount, {from: user2}).should.be.fulfilled;
+      });
+    });
+  }
 
   describe("#burn", async () => {
     it('can burn', async() => {


### PR DESCRIPTION
These changes are to disallow sending tokens directly to [`ValidatorSet`](https://github.com/poanetwork/posdao-contracts/blob/master/contracts/ValidatorSetAuRa.sol) contract because the tokens must only be sent to `ValidatorSet` by [`stake`](https://github.com/poanetwork/posdao-contracts/blob/e47975b152c766625d2a9d49995d3028fe922487/contracts/abstracts/ValidatorSetBase.sol#L149-L156) function.