### PR TITLE
Fix bad initialization of bridge Validators on deploy script

### DIFF
--- a/deploy/src/erc_to_erc/foreign.js
+++ b/deploy/src/erc_to_erc/foreign.js
@@ -141,6 +141,7 @@ async function deployForeign() {
   nonce++
 
   console.log('\ninitializing Foreign Bridge Validators with following parameters:\n')
+  bridgeValidatorsForeign.options.address = storageValidatorsForeign.options.address
   await initializeValidators({
     contract: bridgeValidatorsForeign,
     isRewardableBridge: false,

--- a/deploy/src/erc_to_erc/home.js
+++ b/deploy/src/erc_to_erc/home.js
@@ -188,6 +188,7 @@ async function deployHome() {
   nonce++
 
   console.log('\ninitializing Home Bridge Validators with following parameters:\n')
+  bridgeValidatorsHome.options.address = storageValidatorsHome.options.address
   await initializeValidators({
     contract: bridgeValidatorsHome,
     isRewardableBridge: isRewardableBridge && BLOCK_REWARD_ADDRESS === ZERO_ADDRESS,

--- a/deploy/src/erc_to_native/foreign.js
+++ b/deploy/src/erc_to_native/foreign.js
@@ -118,6 +118,7 @@ async function deployForeign() {
   nonce++
 
   console.log('\ninitializing Foreign Bridge Validators with following parameters:\n')
+  bridgeValidatorsForeign.options.address = storageValidatorsForeign.options.address
   await initializeValidators({
     contract: bridgeValidatorsForeign,
     isRewardableBridge: false,


### PR DESCRIPTION
Fixed a bug that was found while running oracle e2e tests on https://github.com/poanetwork/tokenbridge/pull/67. This bug was introduced on PR https://github.com/poanetwork/poa-bridge-contracts/pull/156. It causes to call `initialize` method of bridge validators on the implementation contract instead of the proxy contract on deployment script.

This issue affected:
- Home side of ERC_TO_ERC
- Foreign side of ERC_TO_ERC
- Foreign side of ERC_TO_NATIVE
