### PR TITLE
Remove coverage build from allow_failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
 env:
   - SOLIDITY_COVERAGE=false
   - SOLIDITY_COVERAGE=true
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: SOLIDITY_COVERAGE=true
 script:
   - yarn lint:js
   - yarn test


### PR DESCRIPTION
Right now on every PR travis display `The Travis CI build passed` when the unit tests build passed ignoring if the coverage build passed or not and do not display any information related to that job.

This PR removes that coverage build is allow to fail, and now travis will wait until both jobs are completed to display if the builds are passing or not