### PR TITLE
several minor fixes

### DIFF
--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -101,7 +101,7 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
     }
 
     function deployedAtBlock() public view returns (uint256) {
-        return uintStorage[keccak256("deployedAtBlock")];
+        return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
     }
 
     function getNextValidator(address _address) public view returns (address) {

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -120,7 +120,7 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
         addressStorage[keccak256(abi.encodePacked("validatorsList", _prevValidator))] = _validator;
     }
 
-    function setInitialize(bool _status) internal {
-        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = _status;
+    function setInitialize() internal {
+        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = true;
     }
 }

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -72,8 +72,8 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, OwnedUpgradeabilit
         return uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))];
     }
 
-    function setInitialize(bool _status) internal {
-        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = _status;
+    function setInitialize() internal {
+        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = true;
     }
 
     function isInitialized() public view returns(bool) {

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -86,11 +86,9 @@ contract BasicHomeBridge is EternalStorage, Validatable {
         boolStorage[keccak256(abi.encodePacked("messagesSigned", _hash))] = _status;
     }
 
-    function onExecuteAffirmation(address, uint256, bytes32) internal returns(bool) {
-    }
+    function onExecuteAffirmation(address, uint256, bytes32) internal returns(bool);
 
-    function onSignaturesCollected(bytes) internal {
-    }
+    function onSignaturesCollected(bytes) internal;
 
     function numAffirmationsSigned(bytes32 _withdrawal) public view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked("numAffirmationsSigned", _withdrawal))];
@@ -157,10 +155,7 @@ contract BasicHomeBridge is EternalStorage, Validatable {
         return Message.requiredMessageLength();
     }
 
-    function affirmationWithinLimits(uint256) internal view returns(bool) {
-        return true;
-    }
+    function affirmationWithinLimits(uint256) internal view returns(bool);
 
-    function onFailedAffirmation(address, uint256, bytes32) internal {
-    }
+    function onFailedAffirmation(address, uint256, bytes32) internal;
 }

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -115,10 +115,6 @@ contract BasicHomeBridge is EternalStorage, Validatable {
         return boolStorage[keccak256(abi.encodePacked("messagesSigned", _message))];
     }
 
-    function messages(bytes32 _hash) internal view returns(bytes) {
-        return bytesStorage[keccak256(abi.encodePacked("messages", _hash))];
-    }
-
     function signatures(bytes32 _hash) internal view returns(bytes) {
         return bytesStorage[keccak256(abi.encodePacked("signatures", _hash))];
     }
@@ -132,7 +128,7 @@ contract BasicHomeBridge is EternalStorage, Validatable {
     }
 
     function message(bytes32 _hash) public view returns (bytes) {
-        return messages(_hash);
+        return bytesStorage[keccak256(abi.encodePacked("messages", _hash))];
     }
 
     function setNumMessagesSigned(bytes32 _message, uint256 _number) internal {

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -108,15 +108,11 @@ contract BasicHomeBridge is EternalStorage, Validatable {
 
     function signature(bytes32 _hash, uint256 _index) public view returns (bytes) {
         bytes32 signIdx = keccak256(abi.encodePacked(_hash, _index));
-        return signatures(signIdx);
+        return bytesStorage[keccak256(abi.encodePacked("signatures", signIdx))];
     }
 
     function messagesSigned(bytes32 _message) public view returns(bool) {
         return boolStorage[keccak256(abi.encodePacked("messagesSigned", _message))];
-    }
-
-    function signatures(bytes32 _hash) internal view returns(bytes) {
-        return bytesStorage[keccak256(abi.encodePacked("signatures", _hash))];
     }
 
     function setSignatures(bytes32 _hash, bytes _signature) internal {

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -40,7 +40,7 @@ contract BridgeValidators is BaseBridgeValidators {
         }
 
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
-        uintStorage[keccak256("deployedAtBlock")] = block.number;
+        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -41,7 +41,7 @@ contract BridgeValidators is BaseBridgeValidators {
 
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
         uintStorage[keccak256("deployedAtBlock")] = block.number;
-        setInitialize(true);
+        setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 
         return isInitialized();

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -20,7 +20,7 @@ contract OverdrawManagement is EternalStorage, OwnedUpgradeability {
         if (unlockOnForeign) {
             emit UserRequestForSignature(recipient, value);
         }
-        setFixedAssets(txHash, true);
+        setFixedAssets(txHash);
     }
 
     function outOfLimitAmount() public view returns(uint256) {
@@ -45,7 +45,7 @@ contract OverdrawManagement is EternalStorage, OwnedUpgradeability {
         uintStorage[keccak256(abi.encodePacked("txOutOfLimitValue", _txHash))] = _value;
     }
 
-    function setFixedAssets(bytes32 _txHash, bool _status) internal {
-        boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))] = _status;
+    function setFixedAssets(bytes32 _txHash) internal {
+        boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))] = true;
     }
 }

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -44,7 +44,7 @@ contract RewardableValidators is BaseBridgeValidators {
         }
 
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
-        uintStorage[keccak256("deployedAtBlock")] = block.number;
+        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -45,7 +45,7 @@ contract RewardableValidators is BaseBridgeValidators {
 
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
         uintStorage[keccak256("deployedAtBlock")] = block.number;
-        setInitialize(true);
+        setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 
         return isInitialized();

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -32,7 +32,7 @@ contract BasicForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setOwner(_owner);
-        setInitialize(true);
+        setInitialize();
     }
 
     function getBridgeMode() public pure returns(bytes4 _data) {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -39,7 +39,7 @@ contract BasicForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
         return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 
-    function claimTokens(address _token, address _to) public onlyIfOwnerOfProxy {
+    function claimTokens(address _token, address _to) public {
         require(_token != address(erc20token()));
         super.claimTokens(_token, _to);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -41,7 +41,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
             _foreignMaxPerTx,
             _owner
         );
-        setInitialize(true);
+        setInitialize();
 
         return isInitialized();
     }
@@ -78,7 +78,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
             _homeFee,
             _foreignFee
         );
-        setInitialize(true);
+        setInitialize();
 
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/POSDAOHomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/POSDAOHomeBridgeErcToErc.sol
@@ -38,7 +38,7 @@ contract POSDAOHomeBridgeErcToErc is HomeBridgeErcToErc {
             _foreignFee
         );
         _setBlockRewardContract(_feeManager, _blockReward);
-        setInitialize(true);
+        setInitialize();
 
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -36,7 +36,7 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setOwner(_owner);
-        setInitialize(true);
+        setInitialize();
         return isInitialized();
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -44,7 +44,7 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
         return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
     }
 
-    function claimTokens(address _token, address _to) public onlyIfOwnerOfProxy {
+    function claimTokens(address _token, address _to) public {
         require(_token != address(erc20token()));
         super.claimTokens(_token, _to);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -193,10 +193,6 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         }
     }
 
-    function fireEventOnTokenTransfer(address _from, uint256 _value) internal {
-        emit UserRequestForSignature(_from, _value);
-    }
-
     function setTotalBurntCoins(uint256 _amount) internal {
         uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))] = _amount;
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -21,7 +21,8 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         require(withinLimit(msg.value));
         IBlockReward blockReward = blockRewardContract();
         uint256 totalMinted = blockReward.mintedTotallyByBridge(address(this));
-        require(msg.value <= totalMinted.sub(totalBurntCoins()));
+        uint256 totalBurnt = totalBurntCoins();
+        require(msg.value <= totalMinted.sub(totalBurnt));
         setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(msg.value));
         uint256 valueToTransfer = msg.value;
         address feeManager = feeManagerContract();
@@ -31,7 +32,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
             valueToTransfer = valueToTransfer.sub(fee);
             valueToBurn = getAmountToBurn(valueToBurn);
         }
-        setTotalBurntCoins(totalBurntCoins().add(valueToBurn));
+        setTotalBurntCoins(totalBurnt.add(valueToBurn));
         address(0).transfer(valueToBurn);
         emit UserRequestForSignature(msg.sender, valueToTransfer);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -19,7 +19,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         nativeTransfer();
     }
 
-    function nativeTransfer() public payable {
+    function nativeTransfer() internal {
         require(msg.value > 0);
         require(msg.data.length == 0);
         require(withinLimit(msg.value));

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -16,6 +16,10 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
     function () public payable {
+        nativeTransfer();
+    }
+
+    function nativeTransfer() public payable {
         require(msg.value > 0);
         require(msg.data.length == 0);
         require(withinLimit(msg.value));

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -62,7 +62,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
             _foreignMaxPerTx,
             _owner
         );
-        setInitialize(true);
+        setInitialize();
 
         return isInitialized();
     }
@@ -99,7 +99,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
-        setInitialize(true);
+        setInitialize();
 
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -38,7 +38,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
             _homeMaxPerTx,
             _owner
         );
-        setInitialize(true);
+        setInitialize();
         return isInitialized();
     }
 
@@ -71,7 +71,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
         require(isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
-        setInitialize(true);
+        setInitialize();
         return isInitialized();
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -11,6 +11,10 @@ import "../Sacrifice.sol";
 contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
 
     function () public payable {
+        nativeTransfer();
+    }
+
+    function nativeTransfer() internal {
         require(msg.value > 0);
         require(msg.data.length == 0);
         require(withinLimit(msg.value));

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -47,7 +47,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
             _foreignMaxPerTx,
             _owner
         );
-        setInitialize(true);
+        setInitialize();
         return isInitialized();
     }
 
@@ -81,7 +81,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
-        setInitialize(true);
+        setInitialize();
         return isInitialized();
     }
 

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -469,6 +469,9 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       expect(await tokenSecond.balanceOf(accounts[0])).to.be.bignumber.equal(ZERO)
       expect(await tokenSecond.balanceOf(foreignBridge.address)).to.be.bignumber.equal(halfEther)
 
+      await foreignBridge
+        .claimTokens(tokenSecond.address, accounts[3], { from: accounts[3] })
+        .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge.claimTokens(tokenSecond.address, accounts[3], { from: owner })
       expect(await tokenSecond.balanceOf(foreignBridge.address)).to.be.bignumber.equal(ZERO)
       expect(await tokenSecond.balanceOf(accounts[3])).to.be.bignumber.equal(halfEther)

--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -497,6 +497,9 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       expect(await tokenSecond.balanceOf(accounts[0])).to.be.bignumber.equal(ZERO)
       expect(await tokenSecond.balanceOf(foreignBridge.address)).to.be.bignumber.equal(halfEther)
 
+      await foreignBridge
+        .claimTokens(tokenSecond.address, accounts[3], { from: accounts[3] })
+        .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge.claimTokens(tokenSecond.address, accounts[3], { from: owner })
       expect(await tokenSecond.balanceOf(foreignBridge.address)).to.be.bignumber.equal(ZERO)
       expect(await tokenSecond.balanceOf(accounts[3])).to.be.bignumber.equal(halfEther)


### PR DESCRIPTION
Changes included in this PR:
- Remove duplicate modifier on claimTokens method https://github.com/poanetwork/poa-bridge-contracts/commit/260cd5613bd49091f36de9f8f31a725f680b603b
- Fix multiple reads of totalBurntCoins https://github.com/poanetwork/poa-bridge-contracts/commit/51e7d9f7638de98c8c01c3ab2603a9957381764d
- Remove parameter on setInitialize https://github.com/poanetwork/poa-bridge-contracts/commit/8fc613bdcb9cf589ad7a64870d7b5bbefeaf8dc2
- Remove status parameter on setFixedAssets https://github.com/poanetwork/poa-bridge-contracts/commit/88d4d5ab70af08f303e839d5cb707aa8fc9d888d
- Remove unused fireEventOnTokenTransfer on HomeBridgeErcToNative https://github.com/poanetwork/poa-bridge-contracts/commit/db9436cc8d5e31a996652009f52054595129a65c
- Redefine empty block methods on BasicHomeBridge https://github.com/poanetwork/poa-bridge-contracts/commit/b74ef32c0330af653817466e749fc29a6e0c9278
- Simplify message method on BasicHomeBridge https://github.com/poanetwork/poa-bridge-contracts/commit/e8e54324c602c0b87de75d71b8ff8c9adfcf46ee
- Simplify signature method on BasicHomeBridge https://github.com/poanetwork/poa-bridge-contracts/commit/e34423675e17411e6eeb2a1e28810c62ff7ef0ef
- Add abi.encodePacked to deployedAtBlock on validators contracts https://github.com/poanetwork/poa-bridge-contracts/commit/13e76f0aca7888d0719c87f67a18c59f9d2f9dc0
- Extract fallback implementation into separate method on HomeBridgeErcToNative https://github.com/poanetwork/poa-bridge-contracts/commit/b498acd63d70d6bd069ddc125e276bac2c664c34

Regarding `deployedAtBlock` change on validator contracts, if an already deployed validator contract needs to be updated, the `deployedAtBlock` value should be migrated to the new key using `abi.encodePacked`.