### PR TITLE
Remove returns from internal initialize method on HomeBridgeErcToErc

### DIFF
--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -98,7 +98,6 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
         uint256 _homeFee,
         uint256 _foreignFee
     ) internal
-    returns(bool)
     {
         _initialize (
             _validatorContract,
@@ -130,7 +129,6 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
         uint256 _foreignMaxPerTx,
         address _owner
     ) internal
-    returns(bool)
     {
         require(!isInitialized());
         require(_validatorContract != address(0) && isContract(_validatorContract));


### PR DESCRIPTION
Closes #215 

Reviewed all method that returns values, fixed internal methods `_initialize` and `_rewardableInitialize` which shouldn't return any value