### PR TITLE
Remove duplicated logic on top of withinExecutionLimit

### DIFF
--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -5,8 +5,9 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
+import "./BasicBridge.sol";
 
-contract BasicForeignBridge is EternalStorage, Validatable {
+contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge {
     using SafeMath for uint256;
     /// triggered when relay of deposit from HomeBridge is complete
     event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
@@ -17,7 +18,7 @@ contract BasicForeignBridge is EternalStorage, Validatable {
         bytes32 txHash;
         address contractAddress;
         (recipient, amount, txHash, contractAddress) = Message.parseMessage(message);
-        if (messageWithinLimits(amount)) {
+        if (withinExecutionLimit(amount)) {
             require(contractAddress == address(this));
             require(!relayedMessages(txHash));
             setRelayedMessages(txHash, true);
@@ -37,8 +38,6 @@ contract BasicForeignBridge is EternalStorage, Validatable {
     function relayedMessages(bytes32 _txHash) public view returns(bool) {
         return boolStorage[keccak256(abi.encodePacked("relayedMessages", _txHash))];
     }
-
-    function messageWithinLimits(uint256) internal view returns(bool);
 
     function onFailedMessage(address, uint256, bytes32) internal;
 }

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -5,9 +5,10 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
+import "./BasicBridge.sol";
 
 
-contract BasicHomeBridge is EternalStorage, Validatable {
+contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);
@@ -17,7 +18,7 @@ contract BasicHomeBridge is EternalStorage, Validatable {
     event CollectedSignatures(address authorityResponsibleForRelay, bytes32 messageHash, uint256 NumberOfCollectedSignatures);
 
     function executeAffirmation(address recipient, uint256 value, bytes32 transactionHash) external onlyValidator {
-        if (affirmationWithinLimits(value)) {
+        if (withinExecutionLimit(value)) {
             bytes32 hashMsg = keccak256(abi.encodePacked(recipient, value, transactionHash));
             bytes32 hashSender = keccak256(abi.encodePacked(msg.sender, hashMsg));
             // Duplicated affirmations
@@ -146,8 +147,6 @@ contract BasicHomeBridge is EternalStorage, Validatable {
     function requiredMessageLength() public pure returns(uint256) {
         return Message.requiredMessageLength();
     }
-
-    function affirmationWithinLimits(uint256) internal view returns(bool);
 
     function onFailedAffirmation(address, uint256, bytes32) internal;
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -1,12 +1,11 @@
 pragma solidity 0.4.24;
 
 
-import "../BasicBridge.sol";
 import "../BasicForeignBridge.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
 
-contract BasicForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
+contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     function _initialize(
         address _validatorContract,
         address _erc20token,
@@ -47,10 +46,6 @@ contract BasicForeignBridgeErcToErc is BasicBridge, BasicForeignBridge {
     function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns(bool){
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
-    }
-
-    function messageWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedMessage(address, uint256, bytes32) internal {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.24;
 
 import "../../libraries/Message.sol";
-import "../BasicBridge.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "../../interfaces/ERC677Receiver.sol";
@@ -11,7 +10,7 @@ import "./RewardableHomeBridgeErcToErc.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 
 
-contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, BasicHomeBridge, ERC677BridgeForBurnableMintableToken, OverdrawManagement, RewardableHomeBridgeErcToErc {
+contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, ERC677BridgeForBurnableMintableToken, OverdrawManagement, RewardableHomeBridgeErcToErc {
 
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
@@ -195,10 +194,6 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicBridge, Basi
             uint256 fee = calculateFee(amount, true, feeManager, HOME_FEE);
             distributeFeeFromSignatures(fee, feeManager, txHash);
         }
-    }
-
-    function affirmationWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -1,13 +1,12 @@
 pragma solidity 0.4.24;
 
 import "../../libraries/Message.sol";
-import "../BasicBridge.sol";
 import "../BasicForeignBridge.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
 
-contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
+contract ForeignBridgeErcToNative is BasicForeignBridge {
     event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
 
     function initialize(
@@ -60,10 +59,6 @@ contract ForeignBridgeErcToNative is BasicBridge, BasicForeignBridge {
     function setErc20token(address _token) private {
         require(_token != address(0) && isContract(_token));
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
-    }
-
-    function messageWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedMessage(address, uint256, bytes32) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.24;
 
 import "../../libraries/Message.sol";
-import "../BasicBridge.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../../interfaces/IBlockReward.sol";
 import "../BasicHomeBridge.sol";
@@ -10,7 +9,7 @@ import "../OverdrawManagement.sol";
 import "./RewardableHomeBridgeErcToNative.sol";
 
 
-contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, OverdrawManagement, RewardableHomeBridgeErcToNative {
+contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManagement, RewardableHomeBridgeErcToNative {
 
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
@@ -198,10 +197,6 @@ contract HomeBridgeErcToNative is EternalStorage, BasicBridge, BasicHomeBridge, 
 
     function setTotalBurntCoins(uint256 _amount) internal {
         uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))] = _amount;
-    }
-
-    function affirmationWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-import "../BasicBridge.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "../../interfaces/ERC677Receiver.sol";
 import "../BasicForeignBridge.sol";
@@ -9,7 +8,7 @@ import "../ERC677BridgeForBurnableMintableToken.sol";
 import "./RewardableForeignBridgeNativeToErc.sol";
 
 
-contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBridge, ERC677BridgeForBurnableMintableToken, RewardableForeignBridgeNativeToErc {
+contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677BridgeForBurnableMintableToken, RewardableForeignBridgeNativeToErc {
 
     /// Event created on money withdraw.
     event UserRequestForAffirmation(address recipient, uint256 value);
@@ -130,10 +129,6 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicBridge, BasicForeignBr
 
     function fireEventOnTokenTransfer(address _from, uint256 _value) internal {
         emit UserRequestForAffirmation(_from, _value);
-    }
-
-    function messageWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedMessage(address, uint256, bytes32) internal {

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -1,14 +1,13 @@
 pragma solidity 0.4.24;
 
 import "../../libraries/Message.sol";
-import "../BasicBridge.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../BasicHomeBridge.sol";
 import "./RewardableHomeBridgeNativeToErc.sol";
 import "../Sacrifice.sol";
 
 
-contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
+contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
 
     function () public payable {
         nativeTransfer();
@@ -154,10 +153,6 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicBridge, BasicHomeBridge, 
             (new Sacrifice).value(valueToTransfer)(_recipient);
         }
         return true;
-    }
-
-    function affirmationWithinLimits(uint256 _amount) internal view returns(bool) {
-        return withinExecutionLimit(_amount);
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {


### PR DESCRIPTION
Closes #212 

All the Home contracts had the same implementation for `affirmationWithinLimits` which calls `withinExecutionLimit` that is defined on `BasicBridge`. It made sense to me to call direclty the method `withinExecutionLimit` from `BasicHomeBridge` and remove `affirmationWithinLimits`. 

In order to do that, I had to change the inheritance of `BasicBridge`. Now `BasicHomeBridge` extends from `BasicBridge` and Home contracts do it througth `BasicHomeBridge`. The changes mentioned are included in this commit https://github.com/poanetwork/poa-bridge-contracts/commit/e314ee373196812c738465eed0754decfada5c2c

I found that this same situation was repeated for `messageWithinLimits` on `BasicForeignBridge` so I applied similar changes to that method too. These are the changes https://github.com/poanetwork/poa-bridge-contracts/commit/becb25aed1dbb17e18df0c88834889f8b5c2718c
