### PR TITLE
Improve contracts names

### DIFF
--- a/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
+++ b/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
 
-interface IOwnedUpgradeabilityProxy {
+interface IUpgradeabilityOwnerStorage {
     function upgradeabilityOwner() public view returns (address);
 }

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 import "../interfaces/IBridgeValidators.sol";
-import "./OwnedUpgradeability.sol";
+import "./Upgradeable.sol";
 import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./Validatable.sol";
@@ -8,7 +8,7 @@ import "./Ownable.sol";
 import "./Claimable.sol";
 
 
-contract BasicBridge is EternalStorage, Validatable, Ownable, OwnedUpgradeability, Claimable {
+contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claimable {
     using SafeMath for uint256;
 
     event GasPriceChanged(uint256 gasPrice);

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -2,11 +2,11 @@ pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./OwnedUpgradeability.sol";
+import "./Upgradeable.sol";
 import "./RewardableBridge.sol";
 
 
-contract OverdrawManagement is EternalStorage, RewardableBridge, OwnedUpgradeability {
+contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);

--- a/contracts/upgradeable_contracts/Upgradeable.sol
+++ b/contracts/upgradeable_contracts/Upgradeable.sol
@@ -1,12 +1,12 @@
 pragma solidity 0.4.24;
 
-import "../interfaces/IOwnedUpgradeabilityProxy.sol";
+import "../interfaces/IUpgradeabilityOwnerStorage.sol";
 
 
 contract Upgradeable {
     // Avoid using onlyUpgradeabilityOwner name to prevent issues with implementation from proxy contract
     modifier onlyIfUpgradeabilityOwner() {
-        require(msg.sender == IOwnedUpgradeabilityProxy(this).upgradeabilityOwner());
+        require(msg.sender == IUpgradeabilityOwnerStorage(this).upgradeabilityOwner());
         _;
     }
 }

--- a/contracts/upgradeable_contracts/Upgradeable.sol
+++ b/contracts/upgradeable_contracts/Upgradeable.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "../interfaces/IOwnedUpgradeabilityProxy.sol";
 
 
-contract OwnedUpgradeability {
+contract Upgradeable {
     // Avoid using onlyUpgradeabilityOwner name to prevent issues with implementation from proxy contract
     modifier onlyIfUpgradeabilityOwner() {
         require(msg.sender == IOwnedUpgradeabilityProxy(this).upgradeabilityOwner());

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 import "./HomeBridgeErcToErc.sol";
 
-contract POSDAOHomeBridgeErcToErc is HomeBridgeErcToErc {
+contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
 
     function rewardableInitialize (
         address _validatorContract,

--- a/deploy/src/erc_to_erc/home.js
+++ b/deploy/src/erc_to_erc/home.js
@@ -23,7 +23,7 @@ const {
     RewardableValidators,
     FeeManagerErcToErcPOSDAO,
     HomeBridgeErcToErc: HomeBridge,
-    POSDAOHomeBridgeErcToErc,
+    HomeBridgeErcToErcPOSDAO,
     ERC677BridgeToken,
     ERC677BridgeTokenRewardable
   }
@@ -221,7 +221,7 @@ async function deployHome() {
   console.log('\ndeploying homeBridge implementation\n')
   const bridgeContract =
     isRewardableBridge && BLOCK_REWARD_ADDRESS !== ZERO_ADDRESS
-      ? POSDAOHomeBridgeErcToErc
+      ? HomeBridgeErcToErcPOSDAO
       : HomeBridge
   const homeBridgeImplementation = await deployContract(bridgeContract, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,

--- a/deploy/src/loadContracts.js
+++ b/deploy/src/loadContracts.js
@@ -18,7 +18,7 @@ function getContracts(evmVersion) {
     HomeBridgeErcToErc: require(`../../build/${buildPath}/HomeBridgeErcToErc.json`),
     ForeignBridgeErcToErc: require(`../../build/${buildPath}/ForeignBridgeErcToErc.json`),
     ForeignBridgeErc677ToErc677: require(`../../build/${buildPath}/ForeignBridgeErc677ToErc677.json`),
-    POSDAOHomeBridgeErcToErc: require(`../../build/${buildPath}/POSDAOHomeBridgeErcToErc.json`),
+    HomeBridgeErcToErcPOSDAO: require(`../../build/${buildPath}/HomeBridgeErcToErcPOSDAO.json`),
     ERC677BridgeToken: require(`../../build/${buildPath}/ERC677BridgeToken.json`),
     ERC677BridgeTokenRewardable: require(`../../build/${buildPath}/ERC677BridgeTokenRewardable.json`),
     ForeignBridgeErcToNative: require(`../../build/${buildPath}/ForeignBridgeErcToNative.json`),

--- a/flatten.sh
+++ b/flatten.sh
@@ -32,7 +32,7 @@ ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/native_to_erc20/FeeManagerNativeToErcBothDi
 
 echo "Flattening contracts related to erc-to-erc bridge"
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/HomeBridgeErcToErc.sol > flats/erc20_to_erc20/HomeBridgeErcToErc_flat.sol
-${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/POSDAOHomeBridgeErcToErc.sol > flats/erc20_to_erc20/POSDAOHomeBridgeErcToErc_flat.sol
+${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol > flats/erc20_to_erc20/HomeBridgeErcToErcPOSDAO_flat.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/ForeignBridgeErcToErc.sol > flats/erc20_to_erc20/ForeignBridgeErcToErc_flat.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol > flats/erc20_to_erc20/ForeignBridgeErc677ToErc677_flat.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol > flats/erc20_to_erc20/FeeManagerErcToErcPOSDAO_flat.sol

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -1,5 +1,5 @@
 const HomeBridge = artifacts.require('HomeBridgeErcToErc.sol')
-const POSDAOHomeBridge = artifacts.require('POSDAOHomeBridgeErcToErc.sol')
+const POSDAOHomeBridge = artifacts.require('HomeBridgeErcToErcPOSDAO.sol')
 const EternalStorageProxy = artifacts.require('EternalStorageProxy.sol')
 const BridgeValidators = artifacts.require('BridgeValidators.sol')
 const ERC677BridgeToken = artifacts.require('ERC677BridgeToken.sol')


### PR DESCRIPTION
Closes #208 

- Renamed `POSDAOHomeBridgeErcToErc` to `HomeBridgeErcToErcPOSDAO`
- Renamed interface `IOwnedUpgradeabilityProxy` to `IUpgradeabilityOwnerStorage` to match the name of the contract where method `upgradeabilityOwner()` is defined.
- Renamed `OwnedUpgradeability` to `Upgradeable`. I think this one was the more confusing, all the contracts that includes the name `upgradeability` adds functionality to the proxy contract but this one was more about consuming methods exposed by those contracts from the implementation contract. 

Please let me know if you can think of a better name for the updated contracts