### PR TITLE
 Fix missing required block confirmation check in ForeignBridgeNativeToErc

### DIFF
--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -97,6 +97,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
+        require(_requiredBlockConfirmations > 0);
         require(_foreignGasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -114,6 +114,20 @@ contract('ForeignBridge', async accounts => {
           owner
         )
         .should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge
+        .initialize(
+          validatorContract.address,
+          token.address,
+          oneEther,
+          halfEther,
+          minPerTx,
+          gasPrice,
+          0,
+          homeDailyLimit,
+          homeMaxPerTx,
+          owner
+        )
+        .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge.initialize(
         validatorContract.address,
         token.address,


### PR DESCRIPTION
I found that all home and foreign contracts had checks for `_requiredBlockConfirmations` parameter on `initialize` method except for `ForeignBridgeNativeToErc`. This PR adds the missing check.