### PR TITLE
Use external modifier instead of public

### DIFF
--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -23,7 +23,7 @@ contract ERC677BridgeToken is
         uint8 _decimals)
     public DetailedERC20(_name, _symbol, _decimals) {}
 
-    function setBridgeContract(address _bridgeContract) onlyOwner public {
+    function setBridgeContract(address _bridgeContract) onlyOwner external {
         require(isContract(_bridgeContract));
         bridgeContract = _bridgeContract;
     }
@@ -45,7 +45,7 @@ contract ERC677BridgeToken is
         return true;
     }
 
-    function getTokenInterfacesVersion() public pure returns(uint64 major, uint64 minor, uint64 patch) {
+    function getTokenInterfacesVersion() external pure returns(uint64 major, uint64 minor, uint64 patch) {
         return (2, 1, 0);
     }
 

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -14,12 +14,12 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
         uint8 _decimals
     ) public ERC677BridgeToken(_name, _symbol, _decimals) {}
 
-    function setBlockRewardContract(address _blockRewardContract) onlyOwner public {
+    function setBlockRewardContract(address _blockRewardContract) onlyOwner external {
         require(isContract(_blockRewardContract));
         blockRewardContract = _blockRewardContract;
     }
 
-    function setStakingContract(address _stakingContract) onlyOwner public {
+    function setStakingContract(address _stakingContract) onlyOwner external {
         require(isContract(_stakingContract));
         stakingContract = _stakingContract;
     }

--- a/contracts/interfaces/IBlockReward.sol
+++ b/contracts/interfaces/IBlockReward.sol
@@ -3,10 +3,10 @@ pragma solidity 0.4.24;
 
 interface IBlockReward {
     function addExtraReceiver(uint256 _amount, address _receiver) external;
-    function mintedTotally() public view returns (uint256);
-    function mintedTotallyByBridge(address _bridge) public view returns(uint256);
+    function mintedTotally() external view returns (uint256);
+    function mintedTotallyByBridge(address _bridge) external view returns(uint256);
     function bridgesAllowedLength() external view returns(uint256);
     function addBridgeTokenFeeReceivers(uint256 _amount) external;
     function addBridgeNativeFeeReceivers(uint256 _amount) external;
-    function blockRewardContractId() public pure returns(bytes4);
+    function blockRewardContractId() external pure returns(bytes4);
 }

--- a/contracts/interfaces/IBridgeValidators.sol
+++ b/contracts/interfaces/IBridgeValidators.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 
 interface IBridgeValidators {
-    function isValidator(address _validator) public view returns(bool);
-    function requiredSignatures() public view returns(uint256);
-    function owner() public view returns(address);
+    function isValidator(address _validator) external view returns(bool);
+    function requiredSignatures() external view returns(uint256);
+    function owner() external view returns(address);
 }

--- a/contracts/interfaces/IRewardableValidators.sol
+++ b/contracts/interfaces/IRewardableValidators.sol
@@ -2,11 +2,11 @@ pragma solidity 0.4.24;
 
 
 interface IRewardableValidators {
-    function isValidator(address _validator) public view returns(bool);
-    function requiredSignatures() public view returns(uint256);
-    function owner() public view returns(address);
-    function validatorList() public view returns (address[]);
-    function getValidatorRewardAddress(address _validator) public view returns(address);
-    function validatorCount() public view returns (uint256);
-    function getNextValidator(address _address) public view returns (address);
+    function isValidator(address _validator) external view returns(bool);
+    function requiredSignatures() external view returns(uint256);
+    function owner() external view returns(address);
+    function validatorList() external view returns (address[]);
+    function getValidatorRewardAddress(address _validator) external view returns(address);
+    function validatorCount() external view returns (uint256);
+    function getNextValidator(address _address) external view returns (address);
 }

--- a/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
+++ b/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
@@ -2,5 +2,5 @@ pragma solidity 0.4.24;
 
 
 interface IUpgradeabilityOwnerStorage {
-    function upgradeabilityOwner() public view returns (address);
+    function upgradeabilityOwner() external view returns (address);
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -35,7 +35,7 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityOwnerStorage, UpgradeabilityP
     * @dev Allows the current owner to transfer control of the contract to a newOwner.
     * @param newOwner The address to transfer ownership to.
     */
-    function transferProxyOwnership(address newOwner) public onlyUpgradeabilityOwner {
+    function transferProxyOwnership(address newOwner) external onlyUpgradeabilityOwner {
         require(newOwner != address(0));
         emit ProxyOwnershipTransferred(upgradeabilityOwner(), newOwner);
         setUpgradeabilityOwner(newOwner);
@@ -58,7 +58,7 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityOwnerStorage, UpgradeabilityP
     * @param data represents the msg.data to bet sent in the low level call. This parameter may include the function
     * signature of the implementation to be called with the needed payload
     */
-    function upgradeToAndCall(uint256 version, address implementation, bytes data) payable public onlyUpgradeabilityOwner {
+    function upgradeToAndCall(uint256 version, address implementation, bytes data) payable external onlyUpgradeabilityOwner {
         upgradeTo(version, implementation);
         require(address(this).call.value(msg.value)(data));
     }

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -16,7 +16,7 @@ contract UpgradeabilityStorage {
     * @dev Tells the version name of the current implementation
     * @return string representing the name of the current version
     */
-    function version() public view returns (uint256) {
+    function version() external view returns (uint256) {
         return _version;
     }
 

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -25,14 +25,14 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
     }
 
     function getBridgeValidatorsInterfacesVersion()
-    public
+    external
     pure
     returns (uint64 major, uint64 minor, uint64 patch)
     {
         return (2, 2, 0);
     }
 
-    function validatorList() public view returns (address[]) {
+    function validatorList() external view returns (address[]) {
         address [] memory list = new address[](validatorCount());
         uint256 counter = 0;
         address nextValidator = getNextValidator(F_ADDR);
@@ -100,7 +100,7 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
         return boolStorage[keccak256(abi.encodePacked("isInitialized"))];
     }
 
-    function deployedAtBlock() public view returns (uint256) {
+    function deployedAtBlock() external view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
     }
 

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -50,7 +50,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
 
     function distributeFeeFromSignatures(uint256 _fee) external;
 
-    function getFeeManagerMode() public pure returns(bytes4);
+    function getFeeManagerMode() external pure returns(bytes4);
 
     function random(uint256 _count) public view returns(uint256) {
         return uint256(blockhash(block.number.sub(1))) % _count;

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -16,31 +16,31 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     event DailyLimitChanged(uint256 newLimit);
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
-    function getBridgeInterfacesVersion() public pure returns(uint64 major, uint64 minor, uint64 patch) {
+    function getBridgeInterfacesVersion() external pure returns(uint64 major, uint64 minor, uint64 patch) {
         return (2, 2, 0);
     }
 
-    function setGasPrice(uint256 _gasPrice) public onlyOwner {
+    function setGasPrice(uint256 _gasPrice) external onlyOwner {
         require(_gasPrice > 0);
         uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;
         emit GasPriceChanged(_gasPrice);
     }
 
-    function gasPrice() public view returns(uint256) {
+    function gasPrice() external view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked("gasPrice"))];
     }
 
-    function setRequiredBlockConfirmations(uint256 _blockConfirmations) public onlyOwner {
+    function setRequiredBlockConfirmations(uint256 _blockConfirmations) external onlyOwner {
         require(_blockConfirmations > 0);
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _blockConfirmations;
         emit RequiredBlockConfirmationChanged(_blockConfirmations);
     }
 
-    function requiredBlockConfirmations() public view returns(uint256) {
+    function requiredBlockConfirmations() external view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))];
     }
 
-    function deployedAtBlock() public view returns(uint256) {
+    function deployedAtBlock() external view returns(uint256) {
         return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
     }
 
@@ -84,7 +84,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         return now / 1 days;
     }
 
-    function setDailyLimit(uint256 _dailyLimit) public onlyOwner {
+    function setDailyLimit(uint256 _dailyLimit) external onlyOwner {
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         emit DailyLimitChanged(_dailyLimit);
     }
@@ -93,7 +93,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         return uintStorage[keccak256(abi.encodePacked("dailyLimit"))];
     }
 
-    function setExecutionDailyLimit(uint256 _dailyLimit) public onlyOwner {
+    function setExecutionDailyLimit(uint256 _dailyLimit) external onlyOwner {
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _dailyLimit;
         emit ExecutionDailyLimitChanged(_dailyLimit);
     }

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -107,7 +107,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         return boolStorage[keccak256(abi.encodePacked("affirmationsSigned", _withdrawal))];
     }
 
-    function signature(bytes32 _hash, uint256 _index) public view returns (bytes) {
+    function signature(bytes32 _hash, uint256 _index) external view returns (bytes) {
         bytes32 signIdx = keccak256(abi.encodePacked(_hash, _index));
         return bytesStorage[keccak256(abi.encodePacked("signatures", signIdx))];
     }
@@ -124,7 +124,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         bytesStorage[keccak256(abi.encodePacked("messages", _hash))] = _message;
     }
 
-    function message(bytes32 _hash) public view returns (bytes) {
+    function message(bytes32 _hash) external view returns (bytes) {
         return bytesStorage[keccak256(abi.encodePacked("messages", _hash))];
     }
 

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -10,7 +10,7 @@ contract BridgeValidators is BaseBridgeValidators {
         address[] _initialValidators,
         address _owner
     )
-        public
+        external
         returns (bool)
     {
         require(!isInitialized());

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -35,7 +35,7 @@ contract Ownable is EternalStorage {
     * @dev Allows the current owner to transfer control of the contract to a newOwner.
     * @param newOwner the address to transfer ownership to.
     */
-    function transferOwnership(address newOwner) public onlyOwner {
+    function transferOwnership(address newOwner) external onlyOwner {
         require(newOwner != address(0));
         setOwner(newOwner);
     }

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -25,7 +25,7 @@ contract RewardableBridge is Ownable, FeeTypes {
         return fee;
     }
 
-    function getFeeManagerMode() public view returns(bytes4) {
+    function getFeeManagerMode() external view returns(bytes4) {
         bytes4 mode;
         bytes memory callData = abi.encodeWithSignature("getFeeManagerMode()");
         address feeManager = feeManagerContract();
@@ -43,7 +43,7 @@ contract RewardableBridge is Ownable, FeeTypes {
         return addressStorage[keccak256(abi.encodePacked("feeManagerContract"))];
     }
 
-    function setFeeManagerContract(address _feeManager) public onlyOwner {
+    function setFeeManagerContract(address _feeManager) external onlyOwner {
         require(_feeManager == address(0) || isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
     }

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -64,7 +64,7 @@ contract RewardableValidators is BaseBridgeValidators {
         emit ValidatorRemoved(_validator);
     }
 
-    function getValidatorRewardAddress(address _validator) public view returns (address) {
+    function getValidatorRewardAddress(address _validator) external view returns (address) {
         return addressStorage[keccak256(abi.encodePacked("validatorsRewards", _validator))];
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -34,7 +34,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         setInitialize();
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -4,11 +4,11 @@ import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
 
-    function getFeeManagerMode() public pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns(bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 
-    function blockRewardContract() public view returns(address) {
+    function blockRewardContract() external view returns(address) {
         return _blockRewardContract();
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -20,7 +20,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) public returns(bool) {
+    ) external returns(bool) {
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
 
         _initialize(

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -14,7 +14,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) public returns(bool) {
+    ) external returns(bool) {
         _initialize(
             _validatorContract,
             _erc20token,

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -25,7 +25,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) public
+    ) external
       returns(bool)
     {
         _initialize (
@@ -59,7 +59,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) public
+    ) external
     returns(bool)
     {
         _rewardableInitialize (
@@ -153,7 +153,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         IBurnableMintableERC677Token(erc677token()).claimTokens(_token, _to);
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -19,7 +19,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         uint256 _homeFee,
         uint256 _foreignFee,
         address _blockReward
-    ) public
+    ) external
     returns(bool)
     {
         _rewardableInitialize (
@@ -59,7 +59,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         return blockReward;
     }
 
-    function setBlockRewardContract(address _blockReward) public onlyOwner {
+    function setBlockRewardContract(address _blockReward) external onlyOwner {
         address feeManager = feeManagerContract();
         _setBlockRewardContract(feeManager, _blockReward);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
@@ -7,7 +7,7 @@ import "../ValidatorsFeeManager.sol";
 
 contract FeeManagerErcToNative is ValidatorsFeeManager {
 
-    function getFeeManagerMode() public pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns(bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
@@ -5,7 +5,7 @@ import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToNativePOSDAO is BlockRewardFeeManager {
 
-    function getFeeManagerMode() public pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns(bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -18,7 +18,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) public returns(bool) {
+    ) external returns(bool) {
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);
@@ -38,7 +38,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         return isInitialized();
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -50,7 +50,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) public returns(bool)
+    ) external returns(bool)
     {
         _initialize(
             _validatorContract,
@@ -83,7 +83,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) public returns(bool)
+    ) external returns(bool)
     {
         _initialize(
             _validatorContract,
@@ -106,7 +106,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         return isInitialized();
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
     }
 
@@ -118,7 +118,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         return uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))];
     }
 
-    function setBlockRewardContract(address _blockReward) public onlyOwner {
+    function setBlockRewardContract(address _blockReward) external onlyOwner {
         require(isContract(_blockReward));
 
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
@@ -7,7 +7,7 @@ import "../ValidatorsFeeManager.sol";
 
 contract FeeManagerNativeToErc is ValidatorsFeeManager {
 
-    function getFeeManagerMode() public pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns(bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
@@ -6,7 +6,7 @@ import "../ValidatorsFeeManager.sol";
 
 contract FeeManagerNativeToErcBothDirections is ValidatorsFeeManager {
 
-    function getFeeManagerMode() public pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns(bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -24,7 +24,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) public returns(bool) {
+    ) external returns(bool) {
         _initialize(
             _validatorContract,
             _erc677token,
@@ -54,7 +54,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         address _owner,
         address _feeManager,
         uint256 _homeFee
-    ) public returns(bool) {
+    ) external returns(bool) {
         _initialize(
             _validatorContract,
             _erc677token,
@@ -74,7 +74,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         return isInitialized();
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -37,7 +37,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) public returns(bool)
+    ) external returns(bool)
     {
         _initialize(
             _validatorContract,
@@ -67,7 +67,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) public returns(bool)
+    ) external returns(bool)
     {
         _initialize(
             _validatorContract,
@@ -88,7 +88,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         return isInitialized();
     }
 
-    function getBridgeMode() public pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns(bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 


### PR DESCRIPTION
Closes #233 

All methods from the list were updated except the following:
 
- **BasicBridge.sol	120** `function withinLimit(uint256 _amount)`
- **BasicBridge.sol	125** `function withinExecutionLimit(uint256 _amount)`

Because both methods are called internally from other methods.

- **ForeignBridgeErcToNative.sol 47**
- **BasicForeignBridgeErcToErc.sol	42**

Because `claimTokens` method is overriding `claimTokens` from BasicBridge and also calling it by `super.claimTokens`, so both methods should have the same visibility and using `external` does not work with `super` which triggers an internal call.

- **ForeignBridgeErc677ToErc677.sol	43**
- **ForeignBridgeErcToErc.sol	31**

Because `erc20token()` is being used by internals calls too.

- **IBurnableMintableERC677Token.sol	6**	 
- **IBurnableMintableERC677Token.sol	7**	 
- **IBurnableMintableERC677Token.sol	8**

Because changing visibility differs with methods defined on imported contract from openzeppelin-solidity `MintableToken.sol`