### PR TITLE
Add Solhint solidity linter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "bracketSpacing": true
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "solhint:recommended",
+  "plugins": ["prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "mark-callable-contracts": "off",
+    "avoid-low-level-calls": "off",
+    "no-inline-assembly": "off",
+    "multiple-sends": "off",
+    "bracket-align": "off",
+    "compiler-version": ["error", "0.4.24"]
+  }
+}

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,1 +1,0 @@
-node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ env:
   - SOLIDITY_COVERAGE=false
   - SOLIDITY_COVERAGE=true
 script:
-  - yarn lint:js
+  - yarn lint
   - yarn test

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -11,7 +11,9 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
 
     event ContractFallbackCallFailed(address from, address to, uint256 value);
 
-    constructor(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {}
+    constructor(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function setBridgeContract(address _bridgeContract) external onlyOwner {
         require(isContract(_bridgeContract));

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -6,24 +6,14 @@ import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import "./interfaces/IBurnableMintableERC677Token.sol";
 import "./upgradeable_contracts/Claimable.sol";
 
-contract ERC677BridgeToken is
-    IBurnableMintableERC677Token,
-    DetailedERC20,
-    BurnableToken,
-    MintableToken,
-    Claimable {
-
+contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, BurnableToken, MintableToken, Claimable {
     address public bridgeContract;
 
-    event ContractFallbackCallFailed(address from, address to, uint value);
+    event ContractFallbackCallFailed(address from, address to, uint256 value);
 
-    constructor(
-        string _name,
-        string _symbol,
-        uint8 _decimals)
-    public DetailedERC20(_name, _symbol, _decimals) {}
+    constructor(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {}
 
-    function setBridgeContract(address _bridgeContract) onlyOwner external {
+    function setBridgeContract(address _bridgeContract) external onlyOwner {
         require(isContract(_bridgeContract));
         bridgeContract = _bridgeContract;
     }
@@ -33,9 +23,7 @@ contract ERC677BridgeToken is
         _;
     }
 
-    function transferAndCall(address _to, uint _value, bytes _data)
-        external validRecipient(_to) returns (bool)
-    {
+    function transferAndCall(address _to, uint256 _value, bytes _data) external validRecipient(_to) returns (bool) {
         require(superTransfer(_to, _value));
         emit Transfer(msg.sender, _to, _value, _data);
 
@@ -45,17 +33,15 @@ contract ERC677BridgeToken is
         return true;
     }
 
-    function getTokenInterfacesVersion() external pure returns(uint64 major, uint64 minor, uint64 patch) {
+    function getTokenInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 1, 0);
     }
 
-    function superTransfer(address _to, uint256 _value) internal returns(bool)
-    {
+    function superTransfer(address _to, uint256 _value) internal returns (bool) {
         return super.transfer(_to, _value);
     }
 
-    function transfer(address _to, uint256 _value) public returns (bool)
-    {
+    function transfer(address _to, uint256 _value) public returns (bool) {
         require(superTransfer(_to, _value));
         callAfterTransfer(msg.sender, _to, _value);
         return true;
@@ -74,17 +60,15 @@ contract ERC677BridgeToken is
         }
     }
 
-    function contractFallback(address _from, address _to, uint _value, bytes _data) private returns(bool) {
-        return _to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256,bytes)",  _from, _value, _data));
+    function contractFallback(address _from, address _to, uint256 _value, bytes _data) private returns (bool) {
+        return _to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256,bytes)", _from, _value, _data));
     }
 
-    function isContract(address _addr)
-        internal
-        view
-        returns (bool)
-    {
-        uint length;
-        assembly { length := extcodesize(_addr) }
+    function isContract(address _addr) internal view returns (bool) {
+        uint256 length;
+        assembly {
+            length := extcodesize(_addr)
+        }
         return length > 0;
     }
 

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -6,7 +6,9 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
     address public blockRewardContract;
     address public stakingContract;
 
-    constructor(string _name, string _symbol, uint8 _decimals) public ERC677BridgeToken(_name, _symbol, _decimals) {}
+    constructor(string _name, string _symbol, uint8 _decimals) public ERC677BridgeToken(_name, _symbol, _decimals) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function setBlockRewardContract(address _blockRewardContract) external onlyOwner {
         require(isContract(_blockRewardContract));

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -2,24 +2,18 @@ pragma solidity 0.4.24;
 
 import "./ERC677BridgeToken.sol";
 
-
 contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
-
     address public blockRewardContract;
     address public stakingContract;
 
-    constructor(
-        string _name,
-        string _symbol,
-        uint8 _decimals
-    ) public ERC677BridgeToken(_name, _symbol, _decimals) {}
+    constructor(string _name, string _symbol, uint8 _decimals) public ERC677BridgeToken(_name, _symbol, _decimals) {}
 
-    function setBlockRewardContract(address _blockRewardContract) onlyOwner external {
+    function setBlockRewardContract(address _blockRewardContract) external onlyOwner {
         require(isContract(_blockRewardContract));
         blockRewardContract = _blockRewardContract;
     }
 
-    function setStakingContract(address _stakingContract) onlyOwner external {
+    function setStakingContract(address _stakingContract) external onlyOwner {
         require(isContract(_stakingContract));
         stakingContract = _stakingContract;
     }
@@ -66,12 +60,12 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
         emit Transfer(stakingContract, _staker, _amount);
     }
 
-    function transfer(address _to, uint256 _value) public returns(bool) {
+    function transfer(address _to, uint256 _value) public returns (bool) {
         require(_to != stakingContract);
         return super.transfer(_to, _value);
     }
 
-    function transferFrom(address _from, address _to, uint256 _value) public returns(bool) {
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
         require(_to != stakingContract);
         return super.transferFrom(_from, _to, _value);
     }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.24;
 
 contract Migrations {
     address public owner;
+    // solhint-disable-next-line var-name-mixedcase
     uint256 public last_completed_migration;
 
     modifier restricted() {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity 0.4.24;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint256 public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  constructor() public {
-    owner = msg.sender;
-  }
+    constructor() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint256 completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }

--- a/contracts/interfaces/ERC677.sol
+++ b/contracts/interfaces/ERC677.sol
@@ -1,10 +1,9 @@
 pragma solidity 0.4.24;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
-
 contract ERC677 is ERC20 {
-    event Transfer(address indexed from, address indexed to, uint value, bytes data);
+    event Transfer(address indexed from, address indexed to, uint256 value, bytes data);
 
-    function transferAndCall(address, uint, bytes) external returns (bool);
+    function transferAndCall(address, uint256, bytes) external returns (bool);
 
 }

--- a/contracts/interfaces/ERC677Receiver.sol
+++ b/contracts/interfaces/ERC677Receiver.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 contract ERC677Receiver {
-  function onTokenTransfer(address _from, uint _value, bytes _data) external returns(bool);
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns (bool);
 }

--- a/contracts/interfaces/IBlockReward.sol
+++ b/contracts/interfaces/IBlockReward.sol
@@ -1,12 +1,11 @@
 pragma solidity 0.4.24;
 
-
 interface IBlockReward {
     function addExtraReceiver(uint256 _amount, address _receiver) external;
     function mintedTotally() external view returns (uint256);
-    function mintedTotallyByBridge(address _bridge) external view returns(uint256);
-    function bridgesAllowedLength() external view returns(uint256);
+    function mintedTotallyByBridge(address _bridge) external view returns (uint256);
+    function bridgesAllowedLength() external view returns (uint256);
     function addBridgeTokenFeeReceivers(uint256 _amount) external;
     function addBridgeNativeFeeReceivers(uint256 _amount) external;
-    function blockRewardContractId() external pure returns(bytes4);
+    function blockRewardContractId() external pure returns (bytes4);
 }

--- a/contracts/interfaces/IBridgeValidators.sol
+++ b/contracts/interfaces/IBridgeValidators.sol
@@ -1,8 +1,7 @@
 pragma solidity 0.4.24;
 
-
 interface IBridgeValidators {
-    function isValidator(address _validator) external view returns(bool);
-    function requiredSignatures() external view returns(uint256);
-    function owner() external view returns(address);
+    function isValidator(address _validator) external view returns (bool);
+    function requiredSignatures() external view returns (uint256);
+    function owner() external view returns (address);
 }

--- a/contracts/interfaces/IBurnableMintableERC677Token.sol
+++ b/contracts/interfaces/IBurnableMintableERC677Token.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.24;
 import "../interfaces/ERC677.sol";
 
-
 contract IBurnableMintableERC677Token is ERC677 {
     function mint(address, uint256) public returns (bool);
     function burn(uint256 _value) public;

--- a/contracts/interfaces/IRewardableValidators.sol
+++ b/contracts/interfaces/IRewardableValidators.sol
@@ -1,12 +1,11 @@
 pragma solidity 0.4.24;
 
-
 interface IRewardableValidators {
-    function isValidator(address _validator) external view returns(bool);
-    function requiredSignatures() external view returns(uint256);
-    function owner() external view returns(address);
+    function isValidator(address _validator) external view returns (bool);
+    function requiredSignatures() external view returns (uint256);
+    function owner() external view returns (address);
     function validatorList() external view returns (address[]);
-    function getValidatorRewardAddress(address _validator) external view returns(address);
+    function getValidatorRewardAddress(address _validator) external view returns (address);
     function validatorCount() external view returns (uint256);
     function getNextValidator(address _address) external view returns (address);
 }

--- a/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
+++ b/contracts/interfaces/IUpgradeabilityOwnerStorage.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 interface IUpgradeabilityOwnerStorage {
     function upgradeabilityOwner() external view returns (address);
 }

--- a/contracts/libraries/Message.sol
+++ b/contracts/libraries/Message.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.24;
 import "../interfaces/IBridgeValidators.sol";
 
-
 library Message {
     // function uintToString(uint256 inputValue) internal pure returns (string) {
     //     // figure out the length of the resulting string
@@ -50,7 +49,7 @@ library Message {
     function parseMessage(bytes message)
         internal
         pure
-        returns(address recipient, uint256 amount, bytes32 txHash, address contractAddress)
+        returns (address recipient, uint256 amount, bytes32 txHash, address contractAddress)
     {
         require(isMessageValid(message));
         assembly {
@@ -61,11 +60,11 @@ library Message {
         }
     }
 
-    function isMessageValid(bytes _msg) internal pure returns(bool) {
+    function isMessageValid(bytes _msg) internal pure returns (bool) {
         return _msg.length == requiredMessageLength();
     }
 
-    function requiredMessageLength() internal pure returns(uint256) {
+    function requiredMessageLength() internal pure returns (uint256) {
         return 104;
     }
 
@@ -94,7 +93,8 @@ library Message {
         uint8[] _vs,
         bytes32[] _rs,
         bytes32[] _ss,
-        IBridgeValidators _validatorContract) internal view {
+        IBridgeValidators _validatorContract
+    ) internal view {
         require(isMessageValid(_message));
         uint256 requiredSignatures = _validatorContract.requiredSignatures();
         // It is not necessary to check that arrays have the same length since it will be handled

--- a/contracts/test/BlockReward.sol
+++ b/contracts/test/BlockReward.sol
@@ -13,7 +13,9 @@ contract BlockReward {
     bytes32 internal constant MINTED_TOTALLY_BY_BRIDGE = "mintedTotallyByBridge";
     address public token;
 
-    function() external payable {}
+    function() external payable {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function addExtraReceiver(uint256 _amount, address _receiver) external {
         require(_amount > 0);

--- a/contracts/test/BlockReward.sol
+++ b/contracts/test/BlockReward.sol
@@ -3,7 +3,6 @@ pragma solidity 0.4.24;
 import "../interfaces/IBlockReward.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-
 contract BlockReward {
     using SafeMath for uint256;
 
@@ -14,8 +13,7 @@ contract BlockReward {
     bytes32 internal constant MINTED_TOTALLY_BY_BRIDGE = "mintedTotallyByBridge";
     address public token;
 
-    function () external payable {
-    }
+    function() external payable {}
 
     function addExtraReceiver(uint256 _amount, address _receiver) external {
         require(_amount > 0);
@@ -29,10 +27,8 @@ contract BlockReward {
         return mintedCoins;
     }
 
-    function mintedTotallyByBridge(address _bridge) public view returns(uint256) {
-        return uintStorage[
-        keccak256(abi.encode(MINTED_TOTALLY_BY_BRIDGE, _bridge))
-        ];
+    function mintedTotallyByBridge(address _bridge) public view returns (uint256) {
+        return uintStorage[keccak256(abi.encode(MINTED_TOTALLY_BY_BRIDGE, _bridge))];
     }
 
     function addMintedTotallyByBridge(uint256 _amount, address _bridge) external {
@@ -91,11 +87,11 @@ contract BlockReward {
         require(token.call(abi.encodeWithSignature("mintReward(address[],uint256[])", receivers, rewards)));
     }
 
-    function random(uint256 _count) public view returns(uint256) {
+    function random(uint256 _count) public view returns (uint256) {
         return uint256(blockhash(block.number.sub(1))) % _count;
     }
 
-    function blockRewardContractId() public pure returns(bytes4) {
+    function blockRewardContractId() public pure returns (bytes4) {
         return bytes4(keccak256("blockReward"));
     }
 }

--- a/contracts/test/Staking.sol
+++ b/contracts/test/Staking.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 contract Staking {
     constructor() public {}
 }

--- a/contracts/test/Staking.sol
+++ b/contracts/test/Staking.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.4.24;
 
 contract Staking {
-    constructor() public {}
+    constructor() public {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 }

--- a/contracts/upgradeability/ClassicEternalStorageProxy.sol
+++ b/contracts/upgradeability/ClassicEternalStorageProxy.sol
@@ -4,6 +4,7 @@ import "./EternalStorage.sol";
 import "./OwnedUpgradeabilityProxy.sol";
 
 contract ClassicEternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {
+    // solhint-disable-next-line no-complex-fallback
     function() public payable {
         address _impl = implementation();
         require(_impl != address(0));

--- a/contracts/upgradeability/ClassicEternalStorageProxy.sol
+++ b/contracts/upgradeability/ClassicEternalStorageProxy.sol
@@ -3,10 +3,8 @@ pragma solidity 0.4.24;
 import "./EternalStorage.sol";
 import "./OwnedUpgradeabilityProxy.sol";
 
-
 contract ClassicEternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {
-
-    function () payable public {
+    function() public payable {
         address _impl = implementation();
         require(_impl != address(0));
         uint256 len = getSize(msg.sig);
@@ -16,12 +14,16 @@ contract ClassicEternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy 
             let result := delegatecall(gas, _impl, ptr, calldatasize, 0, len)
 
             switch result
-            case 0 { revert(0, len) }
-            default { return(0, len) }
+                case 0 {
+                    revert(0, len)
+                }
+                default {
+                    return(0, len)
+                }
         }
     }
 
-    function getSize(bytes4 sig) public view returns(uint256) {
+    function getSize(bytes4 sig) public view returns (uint256) {
         uint256 ret = uintStorage[keccak256(abi.encodePacked("dataSizes", sig))];
         if (ret == 0) {
             ret = 32;

--- a/contracts/upgradeability/EternalStorage.sol
+++ b/contracts/upgradeability/EternalStorage.sol
@@ -1,12 +1,10 @@
 pragma solidity 0.4.24;
 
-
 /**
  * @title EternalStorage
  * @dev This contract holds all the necessary state variables to carry out the storage of any contract.
  */
 contract EternalStorage {
-
     mapping(bytes32 => uint256) internal uintStorage;
     mapping(bytes32 => string) internal stringStorage;
     mapping(bytes32 => address) internal addressStorage;

--- a/contracts/upgradeability/EternalStorageProxy.sol
+++ b/contracts/upgradeability/EternalStorageProxy.sol
@@ -3,7 +3,6 @@ pragma solidity 0.4.24;
 import "./EternalStorage.sol";
 import "./OwnedUpgradeabilityProxy.sol";
 
-
 /**
  * @title EternalStorageProxy
  * @dev This proxy holds the storage of the token contract and delegates every call to the current implementation set.

--- a/contracts/upgradeability/EternalStorageProxy.sol
+++ b/contracts/upgradeability/EternalStorageProxy.sol
@@ -9,4 +9,5 @@ import "./OwnedUpgradeabilityProxy.sol";
  * Besides, it allows to upgrade the token's behaviour towards further implementations, and provides basic
  * authorization control functionalities
  */
+// solhint-disable-next-line no-empty-blocks
 contract EternalStorageProxy is OwnedUpgradeabilityProxy, EternalStorage {}

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -63,6 +63,7 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityOwnerStorage, UpgradeabilityP
         onlyUpgradeabilityOwner
     {
         upgradeTo(version, implementation);
+        // solhint-disable-next-line avoid-call-value
         require(address(this).call.value(msg.value)(data));
     }
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -3,17 +3,16 @@ pragma solidity 0.4.24;
 import "./UpgradeabilityProxy.sol";
 import "./UpgradeabilityOwnerStorage.sol";
 
-
 /**
  * @title OwnedUpgradeabilityProxy
  * @dev This contract combines an upgradeability proxy with basic authorization control functionalities
  */
 contract OwnedUpgradeabilityProxy is UpgradeabilityOwnerStorage, UpgradeabilityProxy {
-  /**
-  * @dev Event to show ownership has been transferred
-  * @param previousOwner representing the address of the previous owner
-  * @param newOwner representing the address of the new owner
-  */
+    /**
+    * @dev Event to show ownership has been transferred
+    * @param previousOwner representing the address of the previous owner
+    * @param newOwner representing the address of the new owner
+    */
     event ProxyOwnershipTransferred(address previousOwner, address newOwner);
 
     /**
@@ -58,7 +57,11 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityOwnerStorage, UpgradeabilityP
     * @param data represents the msg.data to bet sent in the low level call. This parameter may include the function
     * signature of the implementation to be called with the needed payload
     */
-    function upgradeToAndCall(uint256 version, address implementation, bytes data) payable external onlyUpgradeabilityOwner {
+    function upgradeToAndCall(uint256 version, address implementation, bytes data)
+        external
+        payable
+        onlyUpgradeabilityOwner
+    {
         upgradeTo(version, implementation);
         require(address(this).call.value(msg.value)(data));
     }

--- a/contracts/upgradeability/Proxy.sol
+++ b/contracts/upgradeability/Proxy.sol
@@ -16,6 +16,7 @@ contract Proxy {
     * This function will return whatever the implementation call returns
     */
     function() public payable {
+        // solhint-disable-previous-line no-complex-fallback
         address _impl = implementation();
         require(_impl != address(0));
         assembly {

--- a/contracts/upgradeability/Proxy.sol
+++ b/contracts/upgradeability/Proxy.sol
@@ -1,23 +1,21 @@
 pragma solidity 0.4.24;
 
-
 /**
  * @title Proxy
  * @dev Gives the possibility to delegate any call to a foreign implementation.
  */
 contract Proxy {
-
-  /**
-  * @dev Tells the address of the implementation where every call will be delegated.
-  * @return address of the implementation to which it will be delegated
-  */
+    /**
+    * @dev Tells the address of the implementation where every call will be delegated.
+    * @return address of the implementation to which it will be delegated
+    */
     function implementation() public view returns (address);
 
-  /**
-  * @dev Fallback function allowing to perform a delegatecall to the given implementation.
-  * This function will return whatever the implementation call returns
-  */
-    function () payable public {
+    /**
+    * @dev Fallback function allowing to perform a delegatecall to the given implementation.
+    * This function will return whatever the implementation call returns
+    */
+    function() public payable {
         address _impl = implementation();
         require(_impl != address(0));
         assembly {
@@ -85,8 +83,12 @@ contract Proxy {
                 copied to `ptr` from the delegatecall return data
             */
             switch result
-            case 0 { revert(ptr, returndatasize) }
-            default { return(ptr, returndatasize) }
+                case 0 {
+                    revert(ptr, returndatasize)
+                }
+                default {
+                    return(ptr, returndatasize)
+                }
         }
     }
 }

--- a/contracts/upgradeability/UpgradeabilityOwnerStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityOwnerStorage.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 /**
  * @title UpgradeabilityOwnerStorage
  * @dev This contract keeps track of the upgradeability owner

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -3,7 +3,6 @@ pragma solidity 0.4.24;
 import "./Proxy.sol";
 import "./UpgradeabilityStorage.sol";
 
-
 /**
  * @title UpgradeabilityProxy
  * @dev This contract represents a proxy where the implementation address to which it will delegate can be upgraded

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 /**
  * @title UpgradeabilityStorage
  * @dev This contract holds all the necessary state variables to support the upgrade functionality

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -4,37 +4,29 @@ import "./Ownable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../upgradeability/EternalStorage.sol";
 
-
 contract BaseBridgeValidators is EternalStorage, Ownable {
     using SafeMath for uint256;
 
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
     uint256 internal constant MAX_VALIDATORS = 100;
 
-    event ValidatorAdded (address indexed validator);
-    event ValidatorRemoved (address indexed validator);
-    event RequiredSignaturesChanged (uint256 requiredSignatures);
+    event ValidatorAdded(address indexed validator);
+    event ValidatorRemoved(address indexed validator);
+    event RequiredSignaturesChanged(uint256 requiredSignatures);
 
-    function setRequiredSignatures(uint256 _requiredSignatures)
-    external
-    onlyOwner
-    {
+    function setRequiredSignatures(uint256 _requiredSignatures) external onlyOwner {
         require(validatorCount() >= _requiredSignatures);
         require(_requiredSignatures != 0);
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
         emit RequiredSignaturesChanged(_requiredSignatures);
     }
 
-    function getBridgeValidatorsInterfacesVersion()
-    external
-    pure
-    returns (uint64 major, uint64 minor, uint64 patch)
-    {
+    function getBridgeValidatorsInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 2, 0);
     }
 
     function validatorList() external view returns (address[]) {
-        address [] memory list = new address[](validatorCount());
+        address[] memory list = new address[](validatorCount());
         uint256 counter = 0;
         address nextValidator = getNextValidator(F_ADDR);
         require(nextValidator != address(0));

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -5,7 +5,6 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../interfaces/IRewardableValidators.sol";
 import "./FeeTypes.sol";
 
-
 contract BaseFeeManager is EternalStorage, FeeTypes {
     using SafeMath for uint256;
 
@@ -15,7 +14,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
     // This is not a real fee value but a relative value used to calculate the fee percentage
     uint256 internal constant MAX_FEE = 1 ether;
 
-    function calculateFee(uint256 _value, bool _recover, bytes32 _feeType) public view returns(uint256) {
+    function calculateFee(uint256 _value, bool _recover, bytes32 _feeType) public view returns (uint256) {
         uint256 fee = _feeType == HOME_FEE ? getHomeFee() : getForeignFee();
         if (!_recover) {
             return _value.mul(fee).div(MAX_FEE);
@@ -33,7 +32,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
         emit HomeFeeUpdated(_fee);
     }
 
-    function getHomeFee() public view returns(uint256) {
+    function getHomeFee() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("homeFee"))];
     }
 
@@ -42,7 +41,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
         emit ForeignFeeUpdated(_fee);
     }
 
-    function getForeignFee() public view returns(uint256) {
+    function getForeignFee() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("foreignFee"))];
     }
 
@@ -50,9 +49,9 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
 
     function distributeFeeFromSignatures(uint256 _fee) external;
 
-    function getFeeManagerMode() external pure returns(bytes4);
+    function getFeeManagerMode() external pure returns (bytes4);
 
-    function random(uint256 _count) public view returns(uint256) {
+    function random(uint256 _count) public view returns (uint256) {
         return uint256(blockhash(block.number.sub(1))) % _count;
     }
 }

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -7,7 +7,6 @@ import "./Validatable.sol";
 import "./Ownable.sol";
 import "./Claimable.sol";
 
-
 contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claimable {
     using SafeMath for uint256;
 
@@ -16,7 +15,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     event DailyLimitChanged(uint256 newLimit);
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
-    function getBridgeInterfacesVersion() external pure returns(uint64 major, uint64 minor, uint64 patch) {
+    function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 2, 0);
     }
 
@@ -26,7 +25,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         emit GasPriceChanged(_gasPrice);
     }
 
-    function gasPrice() external view returns(uint256) {
+    function gasPrice() external view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("gasPrice"))];
     }
 
@@ -36,11 +35,11 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         emit RequiredBlockConfirmationChanged(_blockConfirmations);
     }
 
-    function requiredBlockConfirmations() external view returns(uint256) {
+    function requiredBlockConfirmations() external view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))];
     }
 
-    function deployedAtBlock() external view returns(uint256) {
+    function deployedAtBlock() external view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
     }
 
@@ -48,7 +47,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))] = _value;
     }
 
-    function totalSpentPerDay(uint256 _day) public view returns(uint256) {
+    function totalSpentPerDay(uint256 _day) public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))];
     }
 
@@ -56,19 +55,19 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))] = _value;
     }
 
-    function totalExecutedPerDay(uint256 _day) public view returns(uint256) {
+    function totalExecutedPerDay(uint256 _day) public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))];
     }
 
-    function minPerTx() public view returns(uint256) {
+    function minPerTx() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("minPerTx"))];
     }
 
-    function maxPerTx() public view returns(uint256) {
+    function maxPerTx() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("maxPerTx"))];
     }
 
-    function executionMaxPerTx() public view returns(uint256) {
+    function executionMaxPerTx() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))];
     }
 
@@ -76,11 +75,11 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         boolStorage[keccak256(abi.encodePacked("isInitialized"))] = true;
     }
 
-    function isInitialized() public view returns(bool) {
+    function isInitialized() public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("isInitialized"))];
     }
 
-    function getCurrentDay() public view returns(uint256) {
+    function getCurrentDay() public view returns (uint256) {
         return now / 1 days;
     }
 
@@ -89,7 +88,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         emit DailyLimitChanged(_dailyLimit);
     }
 
-    function dailyLimit() public view returns(uint256) {
+    function dailyLimit() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("dailyLimit"))];
     }
 
@@ -98,7 +97,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         emit ExecutionDailyLimitChanged(_dailyLimit);
     }
 
-    function executionDailyLimit() public view returns(uint256) {
+    function executionDailyLimit() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))];
     }
 
@@ -117,12 +116,12 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
     }
 
-    function withinLimit(uint256 _amount) public view returns(bool) {
+    function withinLimit(uint256 _amount) public view returns (bool) {
         uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
         return dailyLimit() >= nextLimit && _amount <= maxPerTx() && _amount >= minPerTx();
     }
 
-    function withinExecutionLimit(uint256 _amount) public view returns(bool) {
+    function withinExecutionLimit(uint256 _amount) public view returns (bool) {
         uint256 nextLimit = totalExecutedPerDay(getCurrentDay()).add(_amount);
         return executionDailyLimit() >= nextLimit && _amount <= executionMaxPerTx();
     }
@@ -131,10 +130,11 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         claimValues(_token, _to);
     }
 
-    function isContract(address _addr) internal view returns (bool)
-    {
-        uint length;
-        assembly { length := extcodesize(_addr) }
+    function isContract(address _addr) internal view returns (bool) {
+        uint256 length;
+        assembly {
+            length := extcodesize(_addr)
+        }
         return length > 0;
     }
 }

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -80,6 +80,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function getCurrentDay() public view returns (uint256) {
+        // solhint-disable-next-line not-rely-on-time
         return now / 1 days;
     }
 

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -10,7 +10,7 @@ import "./BasicBridge.sol";
 contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge {
     using SafeMath for uint256;
     /// triggered when relay of deposit from HomeBridge is complete
-    event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
+    event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
     function executeSignatures(uint8[] vs, bytes32[] rs, bytes32[] ss, bytes message) external {
         Message.hasEnoughValidSignatures(message, vs, rs, ss, validatorContract());
         address recipient;
@@ -29,13 +29,13 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge {
         }
     }
 
-    function onExecuteMessage(address, uint256, bytes32) internal returns(bool);
+    function onExecuteMessage(address, uint256, bytes32) internal returns (bool);
 
     function setRelayedMessages(bytes32 _txHash, bool _status) internal {
         boolStorage[keccak256(abi.encodePacked("relayedMessages", _txHash))] = _status;
     }
 
-    function relayedMessages(bytes32 _txHash) public view returns(bool) {
+    function relayedMessages(bytes32 _txHash) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("relayedMessages", _txHash))];
     }
 

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -7,15 +7,18 @@ import "./Validatable.sol";
 import "../libraries/Message.sol";
 import "./BasicBridge.sol";
 
-
 contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
     using SafeMath for uint256;
 
     event UserRequestForSignature(address recipient, uint256 value);
-    event AffirmationCompleted (address recipient, uint256 value, bytes32 transactionHash);
+    event AffirmationCompleted(address recipient, uint256 value, bytes32 transactionHash);
     event SignedForUserRequest(address indexed signer, bytes32 messageHash);
     event SignedForAffirmation(address indexed signer, bytes32 transactionHash);
-    event CollectedSignatures(address authorityResponsibleForRelay, bytes32 messageHash, uint256 NumberOfCollectedSignatures);
+    event CollectedSignatures(
+        address authorityResponsibleForRelay,
+        bytes32 messageHash,
+        uint256 NumberOfCollectedSignatures
+    );
 
     function executeAffirmation(address recipient, uint256 value, bytes32 transactionHash) external onlyValidator {
         if (withinExecutionLimit(value)) {
@@ -67,7 +70,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         }
         setMessagesSigned(hashSender, true);
 
-        bytes32 signIdx = keccak256(abi.encodePacked(hashMsg, (signed-1)));
+        bytes32 signIdx = keccak256(abi.encodePacked(hashMsg, (signed - 1)));
         setSignatures(signIdx, signature);
 
         setNumMessagesSigned(hashMsg, signed);
@@ -87,11 +90,11 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         boolStorage[keccak256(abi.encodePacked("messagesSigned", _hash))] = _status;
     }
 
-    function onExecuteAffirmation(address, uint256, bytes32) internal returns(bool);
+    function onExecuteAffirmation(address, uint256, bytes32) internal returns (bool);
 
     function onSignaturesCollected(bytes) internal;
 
-    function numAffirmationsSigned(bytes32 _withdrawal) public view returns(uint256) {
+    function numAffirmationsSigned(bytes32 _withdrawal) public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("numAffirmationsSigned", _withdrawal))];
     }
 
@@ -103,7 +106,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         uintStorage[keccak256(abi.encodePacked("numAffirmationsSigned", _withdrawal))] = _number;
     }
 
-    function affirmationsSigned(bytes32 _withdrawal) public view returns(bool) {
+    function affirmationsSigned(bytes32 _withdrawal) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("affirmationsSigned", _withdrawal))];
     }
 
@@ -112,7 +115,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         return bytesStorage[keccak256(abi.encodePacked("signatures", signIdx))];
     }
 
-    function messagesSigned(bytes32 _message) public view returns(bool) {
+    function messagesSigned(bytes32 _message) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("messagesSigned", _message))];
     }
 
@@ -132,19 +135,19 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge {
         uintStorage[keccak256(abi.encodePacked("numMessagesSigned", _message))] = _number;
     }
 
-    function markAsProcessed(uint256 _v) internal pure returns(uint256) {
+    function markAsProcessed(uint256 _v) internal pure returns (uint256) {
         return _v | 2 ** 255;
     }
 
-    function isAlreadyProcessed(uint256 _number) public pure returns(bool) {
-        return _number & 2**255 == 2**255;
+    function isAlreadyProcessed(uint256 _number) public pure returns (bool) {
+        return _number & 2 ** 255 == 2 ** 255;
     }
 
-    function numMessagesSigned(bytes32 _message) public view returns(uint256) {
+    function numMessagesSigned(bytes32 _message) public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("numMessagesSigned", _message))];
     }
 
-    function requiredMessageLength() public pure returns(uint256) {
+    function requiredMessageLength() public pure returns (uint256) {
         return Message.requiredMessageLength();
     }
 

--- a/contracts/upgradeable_contracts/BlockRewardFeeManager.sol
+++ b/contracts/upgradeable_contracts/BlockRewardFeeManager.sol
@@ -4,7 +4,6 @@ import "./BaseFeeManager.sol";
 import "../interfaces/IBlockReward.sol";
 
 contract BlockRewardFeeManager is BaseFeeManager {
-
     function distributeFeeFromAffirmation(uint256 _fee) external {
         distributeFeeFromBlockReward(_fee);
     }
@@ -13,7 +12,7 @@ contract BlockRewardFeeManager is BaseFeeManager {
         distributeFeeFromBlockReward(_fee);
     }
 
-    function _blockRewardContract() internal view returns(IBlockReward) {
+    function _blockRewardContract() internal view returns (IBlockReward) {
         return IBlockReward(addressStorage[keccak256(abi.encodePacked("blockRewardContract"))]);
     }
 

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -2,14 +2,8 @@ pragma solidity 0.4.24;
 
 import "./BaseBridgeValidators.sol";
 
-
 contract BridgeValidators is BaseBridgeValidators {
-
-    function initialize(
-        uint256 _requiredSignatures,
-        address[] _initialValidators,
-        address _owner
-    )
+    function initialize(uint256 _requiredSignatures, address[] _initialValidators, address _owner)
         external
         returns (bool)
     {

--- a/contracts/upgradeable_contracts/Claimable.sol
+++ b/contracts/upgradeable_contracts/Claimable.sol
@@ -4,7 +4,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Sacrifice.sol";
 
 contract Claimable {
-
     modifier validAddress(address _to) {
         require(_to != address(0));
         _;
@@ -41,7 +40,9 @@ contract Claimable {
             returnDataResult := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
 
         // Return data is optional

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -1,11 +1,10 @@
 pragma solidity 0.4.24;
 
-
 import "./BasicBridge.sol";
 import "../interfaces/ERC677.sol";
 
 contract ERC677Bridge is BasicBridge {
-    function erc677token() public view returns(ERC677) {
+    function erc677token() public view returns (ERC677) {
         return ERC677(addressStorage[keccak256(abi.encodePacked("erc677token"))]);
     }
 
@@ -14,7 +13,11 @@ contract ERC677Bridge is BasicBridge {
         addressStorage[keccak256(abi.encodePacked("erc677token"))] = _token;
     }
 
-    function onTokenTransfer(address _from, uint256 _value, bytes /*_data*/) external returns(bool) {
+    function onTokenTransfer(
+        address _from,
+        uint256 _value,
+        bytes /*_data*/
+    ) external returns (bool) {
         ERC677 token = erc677token();
         require(msg.sender == address(token));
         require(withinLimit(_value));

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -26,7 +26,11 @@ contract ERC677Bridge is BasicBridge {
         return true;
     }
 
-    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value) internal {
+    function bridgeSpecificActionsOnTokenTransfer(
+        ERC677, /*_token*/
+        address _from,
+        uint256 _value
+    ) internal {
         fireEventOnTokenTransfer(_from, _value);
     }
 

--- a/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
+++ b/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
@@ -1,9 +1,7 @@
 pragma solidity 0.4.24;
 
-
 import "./ERC677Bridge.sol";
 import "../interfaces/IBurnableMintableERC677Token.sol";
-
 
 contract ERC677BridgeForBurnableMintableToken is ERC677Bridge {
     function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value) internal {

--- a/contracts/upgradeable_contracts/FeeTypes.sol
+++ b/contracts/upgradeable_contracts/FeeTypes.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 contract FeeTypes {
     bytes32 internal constant HOME_FEE = keccak256(abi.encodePacked("home-fee"));
     bytes32 internal constant FOREIGN_FEE = keccak256(abi.encodePacked("foreign-fee"));

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -5,7 +5,6 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./Upgradeable.sol";
 import "./RewardableBridge.sol";
 
-
 contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable {
     using SafeMath for uint256;
 
@@ -29,11 +28,11 @@ contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable {
         setFixedAssets(txHash);
     }
 
-    function outOfLimitAmount() public view returns(uint256) {
+    function outOfLimitAmount() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
     }
 
-    function fixedAssets(bytes32 _txHash) public view returns(bool) {
+    function fixedAssets(bytes32 _txHash) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("fixedAssets", _txHash))];
     }
 
@@ -41,7 +40,7 @@ contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable {
         uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
     }
 
-    function txAboveLimits(bytes32 _txHash) internal view returns(address recipient, uint256 value) {
+    function txAboveLimits(bytes32 _txHash) internal view returns (address recipient, uint256 value) {
         recipient = addressStorage[keccak256(abi.encodePacked("txOutOfLimitRecipient", _txHash))];
         value = uintStorage[keccak256(abi.encodePacked("txOutOfLimitValue", _txHash))];
     }

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
 
-
 /**
  * @title Ownable
  * @dev This contract has an owner address providing basic authorization control

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -3,13 +3,11 @@ pragma solidity 0.4.24;
 import "./Ownable.sol";
 import "./FeeTypes.sol";
 
-
 contract RewardableBridge is Ownable, FeeTypes {
-
     event FeeDistributedFromAffirmation(uint256 feeAmount, bytes32 indexed transactionHash);
     event FeeDistributedFromSignatures(uint256 feeAmount, bytes32 indexed transactionHash);
 
-    function _getFee(bytes32 _feeType) internal view returns(uint256) {
+    function _getFee(bytes32 _feeType) internal view returns (uint256) {
         uint256 fee;
         address feeManager = feeManagerContract();
         string memory method = _feeType == HOME_FEE ? "getHomeFee()" : "getForeignFee()";
@@ -20,12 +18,14 @@ contract RewardableBridge is Ownable, FeeTypes {
             fee := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
         return fee;
     }
 
-    function getFeeManagerMode() external view returns(bytes4) {
+    function getFeeManagerMode() external view returns (bytes4) {
         bytes4 mode;
         bytes memory callData = abi.encodeWithSignature("getFeeManagerMode()");
         address feeManager = feeManagerContract();
@@ -34,12 +34,14 @@ contract RewardableBridge is Ownable, FeeTypes {
             mode := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
         return mode;
     }
 
-    function feeManagerContract() public view returns(address) {
+    function feeManagerContract() public view returns (address) {
         return addressStorage[keccak256(abi.encodePacked("feeManagerContract"))];
     }
 
@@ -53,22 +55,34 @@ contract RewardableBridge is Ownable, FeeTypes {
         require(_feeManager.delegatecall(abi.encodeWithSignature(method, _fee)));
     }
 
-    function isContract(address _addr) internal view returns (bool)
-    {
-        uint length;
-        assembly { length := extcodesize(_addr) }
+    function isContract(address _addr) internal view returns (bool) {
+        uint256 length;
+        assembly {
+            length := extcodesize(_addr)
+        }
         return length > 0;
     }
 
-    function calculateFee(uint256 _value, bool _recover, address _impl, bytes32 _feeType) internal view returns(uint256) {
+    function calculateFee(uint256 _value, bool _recover, address _impl, bytes32 _feeType)
+        internal
+        view
+        returns (uint256)
+    {
         uint256 fee;
-        bytes memory callData = abi.encodeWithSignature("calculateFee(uint256,bool,bytes32)", _value, _recover, _feeType);
+        bytes memory callData = abi.encodeWithSignature(
+            "calculateFee(uint256,bool,bytes32)",
+            _value,
+            _recover,
+            _feeType
+        );
         assembly {
             let result := callcode(gas, _impl, 0x0, add(callData, 0x20), mload(callData), 0, 32)
             fee := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
         return fee;
     }

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -2,18 +2,13 @@ pragma solidity 0.4.24;
 
 import "./BaseBridgeValidators.sol";
 
-
 contract RewardableValidators is BaseBridgeValidators {
-
     function initialize(
         uint256 _requiredSignatures,
         address[] _initialValidators,
         address[] _initialRewards,
         address _owner
-    )
-    public
-    returns (bool)
-    {
+    ) public returns (bool) {
         require(!isInitialized());
         require(_owner != address(0));
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/Sacrifice.sol
+++ b/contracts/upgradeable_contracts/Sacrifice.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-
 contract Sacrifice {
     constructor(address _recipient) public payable {
         selfdestruct(_recipient);

--- a/contracts/upgradeable_contracts/Upgradeable.sol
+++ b/contracts/upgradeable_contracts/Upgradeable.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "../interfaces/IUpgradeabilityOwnerStorage.sol";
 
-
 contract Upgradeable {
     // Avoid using onlyUpgradeabilityOwner name to prevent issues with implementation from proxy contract
     modifier onlyIfUpgradeabilityOwner() {

--- a/contracts/upgradeable_contracts/Validatable.sol
+++ b/contracts/upgradeable_contracts/Validatable.sol
@@ -2,9 +2,8 @@ pragma solidity 0.4.24;
 import "../interfaces/IBridgeValidators.sol";
 import "../upgradeability/EternalStorage.sol";
 
-
 contract Validatable is EternalStorage {
-    function validatorContract() public view returns(IBridgeValidators) {
+    function validatorContract() public view returns (IBridgeValidators) {
         return IBridgeValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
     }
 
@@ -13,7 +12,7 @@ contract Validatable is EternalStorage {
         _;
     }
 
-    function requiredSignatures() public view returns(uint256) {
+    function requiredSignatures() public view returns (uint256) {
         return validatorContract().requiredSignatures();
     }
 

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -4,10 +4,13 @@ import "./BaseFeeManager.sol";
 import "../interfaces/IRewardableValidators.sol";
 
 contract ValidatorsFeeManager is BaseFeeManager {
+    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_HOME = keccak256(
+        abi.encodePacked("reward-transferring-from-home")
+    );
 
-    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_HOME = keccak256(abi.encodePacked("reward-transferring-from-home"));
-
-    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_FOREIGN = keccak256(abi.encodePacked("reward-transferring-from-foreign"));
+    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_FOREIGN = keccak256(
+        abi.encodePacked("reward-transferring-from-foreign")
+    );
 
     function distributeFeeFromAffirmation(uint256 _fee) external {
         distributeFeeProportionally(_fee, REWARD_FOR_TRANSFERRING_FROM_FOREIGN);
@@ -17,7 +20,7 @@ contract ValidatorsFeeManager is BaseFeeManager {
         distributeFeeProportionally(_fee, REWARD_FOR_TRANSFERRING_FROM_HOME);
     }
 
-    function rewardableValidatorContract() internal view returns(IRewardableValidators) {
+    function rewardableValidatorContract() internal view returns (IRewardableValidators) {
         return IRewardableValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
     }
 

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -26,6 +26,7 @@ contract ValidatorsFeeManager is BaseFeeManager {
 
     function distributeFeeProportionally(uint256 _fee, bytes32 _direction) internal {
         IRewardableValidators validators = rewardableValidatorContract();
+        // solhint-disable-next-line var-name-mixedcase
         address F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
         uint256 numOfValidators = validators.validatorCount();
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -1,9 +1,7 @@
 pragma solidity 0.4.24;
 
-
 import "../BasicForeignBridge.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
-
 
 contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     function _initialize(
@@ -34,7 +32,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         setInitialize();
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 
@@ -43,7 +41,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         super.claimTokens(_token, _to);
     }
 
-    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns(bool){
+    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
     }
@@ -52,7 +50,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         revert();
     }
 
-    function erc20token() public view returns(ERC20Basic);
+    function erc20token() public view returns (ERC20Basic);
 
     function setErc20token(address _token) internal;
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -41,7 +41,11 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         super.claimTokens(_token, _to);
     }
 
-    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns (bool) {
+    function onExecuteMessage(
+        address _recipient,
+        uint256 _amount,
+        bytes32 /*_txHash*/
+    ) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -3,12 +3,11 @@ pragma solidity 0.4.24;
 import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
-
-    function getFeeManagerMode() external pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 
-    function blockRewardContract() external view returns(address) {
+    function blockRewardContract() external view returns (address) {
         return _blockRewardContract();
     }
 
@@ -19,7 +18,8 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
         // call a specific method from the contract that should return a specific value
         bool isBlockRewardContract = false;
         if (_blockReward.call(abi.encodeWithSignature("blockRewardContractId()"))) {
-            isBlockRewardContract = IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
+            isBlockRewardContract =
+                IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
         } else if (_blockReward.call(abi.encodeWithSignature("bridgesAllowedLength()"))) {
             isBlockRewardContract = IBlockReward(_blockReward).bridgesAllowedLength() != 0;
         }
@@ -32,10 +32,11 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
         blockReward.addBridgeTokenFeeReceivers(_fee);
     }
 
-    function isContract(address _addr) internal view returns (bool)
-    {
-        uint length;
-        assembly { length := extcodesize(_addr) }
+    function isContract(address _addr) internal view returns (bool) {
+        uint256 length;
+        assembly {
+            length := extcodesize(_addr)
+        }
         return length > 0;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -1,12 +1,9 @@
 pragma solidity 0.4.24;
 
-
 import "./BasicForeignBridgeErcToErc.sol";
 import "../ERC677Bridge.sol";
 
-
 contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc {
-
     event UserRequestForAffirmation(address recipient, uint256 value);
 
     function initialize(
@@ -20,7 +17,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) external returns(bool) {
+    ) external returns (bool) {
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
 
         _initialize(
@@ -40,7 +37,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         return isInitialized();
     }
 
-    function erc20token() public view returns(ERC20Basic) {
+    function erc20token() public view returns (ERC20Basic) {
         return erc677token();
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -1,8 +1,6 @@
 pragma solidity 0.4.24;
 
-
 import "./BasicForeignBridgeErcToErc.sol";
-
 
 contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
     function initialize(
@@ -14,7 +12,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) external returns(bool) {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _erc20token,
@@ -28,7 +26,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
         return isInitialized();
     }
 
-    function erc20token() public view returns(ERC20Basic) {
+    function erc20token() public view returns (ERC20Basic) {
         return ERC20Basic(addressStorage[keccak256(abi.encodePacked("erc20token"))]);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -9,12 +9,17 @@ import "../OverdrawManagement.sol";
 import "./RewardableHomeBridgeErcToErc.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 
-
-contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, ERC677BridgeForBurnableMintableToken, OverdrawManagement, RewardableHomeBridgeErcToErc {
-
+contract HomeBridgeErcToErc is
+    ERC677Receiver,
+    EternalStorage,
+    BasicHomeBridge,
+    ERC677BridgeForBurnableMintableToken,
+    OverdrawManagement,
+    RewardableHomeBridgeErcToErc
+{
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
-    function initialize (
+    function initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -25,10 +30,8 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) external
-      returns(bool)
-    {
-        _initialize (
+    ) external returns (bool) {
+        _initialize(
             _validatorContract,
             _dailyLimit,
             _maxPerTx,
@@ -45,7 +48,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         return isInitialized();
     }
 
-    function rewardableInitialize (
+    function rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -59,10 +62,8 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) external
-    returns(bool)
-    {
-        _rewardableInitialize (
+    ) external returns (bool) {
+        _rewardableInitialize(
             _validatorContract,
             _dailyLimit,
             _maxPerTx,
@@ -82,7 +83,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         return isInitialized();
     }
 
-    function _rewardableInitialize (
+    function _rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -96,9 +97,8 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) internal
-    {
-        _initialize (
+    ) internal {
+        _initialize(
             _validatorContract,
             _dailyLimit,
             _maxPerTx,
@@ -116,7 +116,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
     }
 
-    function _initialize (
+    function _initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -127,8 +127,7 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) internal
-    {
+    ) internal {
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_requiredBlockConfirmations > 0);
@@ -152,11 +151,11 @@ contract HomeBridgeErcToErc is ERC677Receiver, EternalStorage, BasicHomeBridge, 
         IBurnableMintableERC677Token(erc677token()).claimTokens(_token, _to);
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
     }
 
-    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns(bool) {
+    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_value));
         uint256 valueToMint = _value;
         address feeManager = feeManagerContract();

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -3,8 +3,7 @@ pragma solidity 0.4.24;
 import "./HomeBridgeErcToErc.sol";
 
 contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
-
-    function rewardableInitialize (
+    function rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -19,10 +18,8 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         uint256 _homeFee,
         uint256 _foreignFee,
         address _blockReward
-    ) external
-    returns(bool)
-    {
-        _rewardableInitialize (
+    ) external returns (bool) {
+        _rewardableInitialize(
             _validatorContract,
             _dailyLimit,
             _maxPerTx,
@@ -43,7 +40,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         return isInitialized();
     }
 
-    function blockRewardContract() public view returns(address) {
+    function blockRewardContract() public view returns (address) {
         address blockReward;
         address feeManager = feeManagerContract();
         bytes memory callData = abi.encodeWithSignature("blockRewardContract()");
@@ -53,7 +50,9 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
             blockReward := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
 
         return blockReward;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/RewardableHomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/RewardableHomeBridgeErcToErc.sol
@@ -2,9 +2,7 @@ pragma solidity 0.4.24;
 
 import "../RewardableBridge.sol";
 
-
 contract RewardableHomeBridgeErcToErc is RewardableBridge {
-
     function setHomeFee(uint256 _fee) external onlyOwner {
         _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
@@ -13,11 +11,11 @@ contract RewardableHomeBridgeErcToErc is RewardableBridge {
         _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
     }
 
-    function getHomeFee() public view returns(uint256) {
+    function getHomeFee() public view returns (uint256) {
         return _getFee(HOME_FEE);
     }
 
-    function getForeignFee() public view returns(uint256) {
+    function getForeignFee() public view returns (uint256) {
         return _getFee(FOREIGN_FEE);
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
@@ -4,14 +4,12 @@ import "../../interfaces/IBlockReward.sol";
 import "../Sacrifice.sol";
 import "../ValidatorsFeeManager.sol";
 
-
 contract FeeManagerErcToNative is ValidatorsFeeManager {
-
-    function getFeeManagerMode() external pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 
-    function blockRewardContract() internal view returns(IBlockReward) {
+    function blockRewardContract() internal view returns (IBlockReward) {
         return IBlockReward(addressStorage[keccak256(abi.encodePacked("blockRewardContract"))]);
     }
 
@@ -26,7 +24,7 @@ contract FeeManagerErcToNative is ValidatorsFeeManager {
         }
     }
 
-    function getAmountToBurn(uint256 _value) public view returns(uint256) {
+    function getAmountToBurn(uint256 _value) public view returns (uint256) {
         uint256 fee = calculateFee(_value, false, HOME_FEE);
         return _value.sub(fee);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
@@ -4,8 +4,7 @@ import "../../interfaces/IBlockReward.sol";
 import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToNativePOSDAO is BlockRewardFeeManager {
-
-    function getFeeManagerMode() external pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 
@@ -14,7 +13,7 @@ contract FeeManagerErcToNativePOSDAO is BlockRewardFeeManager {
         blockReward.addBridgeNativeFeeReceivers(_fee);
     }
 
-    function getAmountToBurn(uint256 _value) public view returns(uint256) {
+    function getAmountToBurn(uint256 _value) public view returns (uint256) {
         return _value;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -50,7 +50,11 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         return ERC20Basic(addressStorage[keccak256(abi.encodePacked("erc20token"))]);
     }
 
-    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns (bool) {
+    function onExecuteMessage(
+        address _recipient,
+        uint256 _amount,
+        bytes32 /*_txHash*/
+    ) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -5,9 +5,8 @@ import "../BasicForeignBridge.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 
-
 contract ForeignBridgeErcToNative is BasicForeignBridge {
-    event RelayedMessage(address recipient, uint value, bytes32 transactionHash);
+    event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
 
     function initialize(
         address _validatorContract,
@@ -18,7 +17,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) external returns(bool) {
+    ) external returns (bool) {
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);
@@ -38,7 +37,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         return isInitialized();
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
     }
 
@@ -47,11 +46,11 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         super.claimTokens(_token, _to);
     }
 
-    function erc20token() public view returns(ERC20Basic) {
+    function erc20token() public view returns (ERC20Basic) {
         return ERC20Basic(addressStorage[keccak256(abi.encodePacked("erc20token"))]);
     }
 
-    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns(bool) {
+    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -8,12 +8,10 @@ import "../ERC677Bridge.sol";
 import "../OverdrawManagement.sol";
 import "./RewardableHomeBridgeErcToNative.sol";
 
-
 contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManagement, RewardableHomeBridgeErcToNative {
-
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
-    function () public payable {
+    function() public payable {
         nativeTransfer();
     }
 
@@ -39,7 +37,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         emit UserRequestForSignature(msg.sender, valueToTransfer);
     }
 
-    function initialize (
+    function initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -50,8 +48,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) external returns(bool)
-    {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimit,
@@ -69,7 +66,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         return isInitialized();
     }
 
-    function rewardableInitialize (
+    function rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -83,8 +80,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) external returns(bool)
-    {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimit,
@@ -106,15 +102,15 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         return isInitialized();
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
     }
 
-    function blockRewardContract() public view returns(IBlockReward) {
+    function blockRewardContract() public view returns (IBlockReward) {
         return IBlockReward(addressStorage[keccak256(abi.encodePacked("blockRewardContract"))]);
     }
 
-    function totalBurntCoins() public view returns(uint256) {
+    function totalBurntCoins() public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))];
     }
 
@@ -125,7 +121,8 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         // call a specific method from the contract that should return a specific value
         bool isBlockRewardContract = false;
         if (_blockReward.call(abi.encodeWithSignature("blockRewardContractId()"))) {
-            isBlockRewardContract = IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
+            isBlockRewardContract =
+                IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
         } else if (_blockReward.call(abi.encodeWithSignature("bridgesAllowedLength()"))) {
             isBlockRewardContract = IBlockReward(_blockReward).bridgesAllowedLength() != 0;
         }
@@ -133,7 +130,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
     }
 
-    function _initialize (
+    function _initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -144,8 +141,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) internal
-    {
+    ) internal {
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_requiredBlockConfirmations > 0);
@@ -166,7 +162,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         setOwner(_owner);
     }
 
-    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns(bool) {
+    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_value));
         IBlockReward blockReward = blockRewardContract();
         require(blockReward != address(0));

--- a/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
@@ -2,9 +2,7 @@ pragma solidity 0.4.24;
 
 import "../RewardableBridge.sol";
 
-
 contract RewardableHomeBridgeErcToNative is RewardableBridge {
-
     function setHomeFee(uint256 _fee) external onlyOwner {
         _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
@@ -13,15 +11,15 @@ contract RewardableHomeBridgeErcToNative is RewardableBridge {
         _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
     }
 
-    function getHomeFee() public view returns(uint256) {
+    function getHomeFee() public view returns (uint256) {
         return _getFee(HOME_FEE);
     }
 
-    function getForeignFee() public view returns(uint256) {
+    function getForeignFee() public view returns (uint256) {
         return _getFee(FOREIGN_FEE);
     }
 
-    function getAmountToBurn(uint256 _value) public view returns(uint256) {
+    function getAmountToBurn(uint256 _value) public view returns (uint256) {
         uint256 amount;
         bytes memory callData = abi.encodeWithSignature("getAmountToBurn(uint256)", _value);
         address feeManager = feeManagerContract();
@@ -30,7 +28,9 @@ contract RewardableHomeBridgeErcToNative is RewardableBridge {
             amount := mload(0)
 
             switch result
-            case 0 { revert(0, 0) }
+                case 0 {
+                    revert(0, 0)
+                }
         }
         return amount;
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/ClassicHomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ClassicHomeBridgeNativeToErc.sol
@@ -2,10 +2,8 @@ pragma solidity 0.4.24;
 
 import "./HomeBridgeNativeToErc.sol";
 
-
 contract ClassicHomeBridgeNativeToErc is HomeBridgeNativeToErc {
-
-    function _initialize (
+    function _initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -15,8 +13,7 @@ contract ClassicHomeBridgeNativeToErc is HomeBridgeNativeToErc {
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) internal
-    {
+    ) internal {
         super._initialize(
             _validatorContract,
             _dailyLimit,

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
@@ -4,14 +4,12 @@ import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "../Sacrifice.sol";
 import "../ValidatorsFeeManager.sol";
 
-
 contract FeeManagerNativeToErc is ValidatorsFeeManager {
-
-    function getFeeManagerMode() external pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
     }
 
-    function erc677token() public view returns(IBurnableMintableERC677Token) {
+    function erc677token() public view returns (IBurnableMintableERC677Token) {
         return IBurnableMintableERC677Token(addressStorage[keccak256(abi.encodePacked("erc677token"))]);
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
@@ -3,10 +3,8 @@ pragma solidity 0.4.24;
 import "../Sacrifice.sol";
 import "../ValidatorsFeeManager.sol";
 
-
 contract FeeManagerNativeToErcBothDirections is ValidatorsFeeManager {
-
-    function getFeeManagerMode() external pure returns(bytes4) {
+    function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -7,9 +7,12 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 import "./RewardableForeignBridgeNativeToErc.sol";
 
-
-contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677BridgeForBurnableMintableToken, RewardableForeignBridgeNativeToErc {
-
+contract ForeignBridgeNativeToErc is
+    ERC677Receiver,
+    BasicForeignBridge,
+    ERC677BridgeForBurnableMintableToken,
+    RewardableForeignBridgeNativeToErc
+{
     /// Event created on money withdraw.
     event UserRequestForAffirmation(address recipient, uint256 value);
 
@@ -24,7 +27,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         uint256 _homeDailyLimit,
         uint256 _homeMaxPerTx,
         address _owner
-    ) external returns(bool) {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _erc677token,
@@ -54,7 +57,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         address _owner,
         address _feeManager,
         uint256 _homeFee
-    ) external returns(bool) {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _erc677token,
@@ -74,7 +77,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         return isInitialized();
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 
@@ -114,7 +117,7 @@ contract ForeignBridgeNativeToErc is ERC677Receiver, BasicForeignBridge, ERC677B
         setOwner(_owner);
     }
 
-    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns(bool) {
+    function onExecuteMessage(address _recipient, uint256 _amount, bytes32 _txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         uint256 valueToMint = _amount;
         address feeManager = feeManagerContract();

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -150,7 +150,11 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         return true;
     }
 
-    function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {
+    function onFailedAffirmation(
+        address, /*_recipient*/
+        uint256, /*_value*/
+        bytes32 /*_txHash*/
+    ) internal {
         revert();
     }
 }

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -6,10 +6,8 @@ import "../BasicHomeBridge.sol";
 import "./RewardableHomeBridgeNativeToErc.sol";
 import "../Sacrifice.sol";
 
-
 contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
-
-    function () public payable {
+    function() public payable {
         nativeTransfer();
     }
 
@@ -27,7 +25,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         emit UserRequestForSignature(msg.sender, valueToTransfer);
     }
 
-    function initialize (
+    function initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -37,8 +35,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) external returns(bool)
-    {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimit,
@@ -54,7 +51,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         return isInitialized();
     }
 
-    function rewardableInitialize (
+    function rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -67,8 +64,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         address _feeManager,
         uint256 _homeFee,
         uint256 _foreignFee
-    ) external returns(bool)
-    {
+    ) external returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimit,
@@ -88,11 +84,11 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         return isInitialized();
     }
 
-    function getBridgeMode() external pure returns(bytes4 _data) {
+    function getBridgeMode() external pure returns (bytes4 _data) {
         return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
     }
 
-    function _initialize (
+    function _initialize(
         address _validatorContract,
         uint256 _dailyLimit,
         uint256 _maxPerTx,
@@ -102,8 +98,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uint256 _foreignDailyLimit,
         uint256 _foreignMaxPerTx,
         address _owner
-    ) internal
-    {
+    ) internal {
         require(!isInitialized());
         require(isContract(_validatorContract));
         require(_homeGasPrice > 0);
@@ -138,7 +133,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         }
     }
 
-    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns(bool) {
+    function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_value));
         uint256 valueToTransfer = _value;
 

--- a/contracts/upgradeable_contracts/native_to_erc20/RewardableForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/RewardableForeignBridgeNativeToErc.sol
@@ -2,14 +2,12 @@ pragma solidity 0.4.24;
 
 import "../RewardableBridge.sol";
 
-
 contract RewardableForeignBridgeNativeToErc is RewardableBridge {
-
     function setHomeFee(uint256 _fee) external onlyOwner {
         _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
 
-    function getHomeFee() public view returns(uint256) {
+    function getHomeFee() public view returns (uint256) {
         return _getFee(HOME_FEE);
     }
 }

--- a/contracts/upgradeable_contracts/native_to_erc20/RewardableHomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/RewardableHomeBridgeNativeToErc.sol
@@ -2,9 +2,7 @@ pragma solidity 0.4.24;
 
 import "../RewardableBridge.sol";
 
-
 contract RewardableHomeBridgeNativeToErc is RewardableBridge {
-
     function setForeignFee(uint256 _fee) external onlyOwner {
         _setFee(feeManagerContract(), _fee, FOREIGN_FEE);
     }
@@ -13,11 +11,11 @@ contract RewardableHomeBridgeNativeToErc is RewardableBridge {
         _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
 
-    function getForeignFee() public view returns(uint256) {
+    function getForeignFee() public view returns (uint256) {
         return _getFee(FOREIGN_FEE);
     }
 
-    function getHomeFee() public view returns(uint256) {
+    function getHomeFee() public view returns (uint256) {
         return _getFee(HOME_FEE);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,6 +1547,21 @@
         "debug": "^3.1.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
     "@types/bn.js": {
       "version": "4.11.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
@@ -1652,6 +1667,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-11.1.2.tgz",
       "integrity": "sha512-zG61PAp2OcoIBjRV44wftJj6AJgzJrOc32LCYOBqk9bdgcdzK5DCJHV9QZJ60+Fu+fOn79g8Ks3Gixm4CfkZ+w=="
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1696,6 +1721,24 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
     },
     "ajv": {
       "version": "6.10.0",
@@ -1775,6 +1818,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "antlr4": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.7.1.tgz",
+      "integrity": "sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -1802,8 +1851,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "optional": true
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -2808,6 +2856,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -3000,6 +3054,71 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true
+    },
+    "cacache": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.0.tgz",
+      "integrity": "sha512-0baf1FhCp16LhN+xDJsOrSiaPDCTD3JegZptVmLDoEbFcT5aT+BeFGt3wcDU3olCP5tpTCXU5sv0+TsKWT9WGQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -3016,10 +3135,90 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "caniuse-lite": {
@@ -3138,13 +3337,18 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-      "optional": true
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "cint": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
+      "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
     },
     "cipher-base": {
@@ -3190,6 +3394,23 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
       }
     },
     "cli-table3": {
@@ -3246,6 +3467,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -3369,6 +3599,20 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -3415,6 +3659,40 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
     },
     "coveralls": {
       "version": "3.0.4",
@@ -3525,6 +3803,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
       "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3581,6 +3865,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+      "dev": true
     },
     "deferred-leveldown": {
       "version": "1.2.2",
@@ -3675,6 +3965,12 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
+    "dir-to-object": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-to-object/-/dir-to-object-2.0.0.tgz",
+      "integrity": "sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3713,6 +4009,18 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3764,6 +4072,12 @@
         "once": "^1.4.0"
       }
     },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -3802,6 +4116,21 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -4187,6 +4516,23 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+    },
+    "esprima-extract-comments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
+      "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        }
+      }
     },
     "esquery": {
       "version": "1.0.1",
@@ -4908,6 +5254,16 @@
         }
       }
     },
+    "extract-comments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
+      "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
+      "dev": true,
+      "requires": {
+        "esprima-extract-comments": "^1.1.0",
+        "parse-code-context": "^1.0.0"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4949,6 +5305,12 @@
       "requires": {
         "node-fetch": "~1.7.1"
       }
+    },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
@@ -4994,6 +5356,51 @@
         }
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -5010,6 +5417,16 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -5047,6 +5464,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5063,6 +5490,27 @@
         "klaw": "^1.0.0",
         "path-is-absolute": "^1.0.0",
         "rimraf": "^2.2.8"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -17232,6 +17680,12 @@
         "wide-align": "^1.1.0"
       }
     },
+    "genfun": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -17455,6 +17909,12 @@
         }
       }
     },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
     "hash-base": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -17524,6 +17984,22 @@
         "parse-cache-control": "^1.0.1"
       }
     },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      }
+    },
     "http-response-object": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
@@ -17543,6 +18019,25 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -17556,6 +18051,12 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -17567,6 +18068,15 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "immediate": {
       "version": "3.2.3",
@@ -17714,6 +18224,12 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -17804,6 +18320,12 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -17960,6 +18482,12 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -18055,6 +18583,12 @@
         }
       }
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -18090,6 +18624,27 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-rpc-engine": {
       "version": "3.8.0",
@@ -18174,6 +18729,12 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
     "jsonschema": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
@@ -18201,6 +18762,15 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -18213,6 +18783,12 @@
       "requires": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
@@ -18359,6 +18935,68 @@
         "type-check": "~0.3.2"
       }
     },
+    "libnpmconfig": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -18442,6 +19080,42 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "make-fetch-happen": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
+      "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+      "dev": true,
+      "requires": {
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^12.0.0",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -18594,6 +19268,63 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -18636,6 +19367,20 @@
         "he": "1.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "4.4.0"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -18689,6 +19434,12 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
+    "nested-error-stacks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
+      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -18704,6 +19455,43 @@
         "semver": "^5.4.1"
       }
     },
+    "node-alias": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-alias/-/node-alias-1.0.4.tgz",
+      "integrity": "sha1-HxuRa1a56iQcATX5fO1pQPVW8pI=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "lodash": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -18711,6 +19499,17 @@
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
+      }
+    },
+    "node-fetch-npm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node-hid": {
@@ -18806,6 +19605,337 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "normalize-url": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+      "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+      "dev": true
+    },
+    "npm-check-updates": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.20.tgz",
+      "integrity": "sha512-mc9BAoOYSTwP/IvoA+ofdkWSipwRvhgC0qop1PvlMZojgzi7N/dykdxOIWrw0OlZPnEKvXkKFEuPk97LrvXE1A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "cint": "^8.2.1",
+        "cli-table": "^0.3.1",
+        "commander": "^2.20.0",
+        "fast-diff": "^1.2.0",
+        "find-up": "4.1.0",
+        "get-stdin": "^7.0.0",
+        "json-parse-helpfulerror": "^1.0.3",
+        "libnpmconfig": "^1.2.1",
+        "lodash": "^4.17.13",
+        "node-alias": "^1.0.4",
+        "pacote": "^9.5.1",
+        "progress": "^2.0.3",
+        "prompts": "^2.1.0",
+        "rc-config-loader": "^2.0.4",
+        "requireg": "^0.2.2",
+        "semver": "^6.2.0",
+        "semver-utils": "^1.1.4",
+        "spawn-please": "^0.3.0",
+        "update-notifier": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-align": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+          "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "boxen": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+          "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^2.4.2",
+            "cli-boxes": "^2.2.0",
+            "string-width": "^3.0.0",
+            "term-size": "^1.2.0",
+            "type-fest": "^0.3.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "cli-boxes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+          "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
+        "configstore": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+          "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-npm": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+          "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+          "dev": true
+        },
+        "latest-version": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+          "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+          "dev": true,
+          "requires": {
+            "package-json": "^6.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "package-json": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz",
+          "integrity": "sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==",
+          "dev": true,
+          "requires": {
+            "got": "^9.6.0",
+            "registry-auth-token": "^3.4.0",
+            "registry-url": "^5.0.0",
+            "semver": "^6.1.1"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "registry-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+          "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+          "dev": true,
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "update-notifier": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+          "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+          "dev": true,
+          "requires": {
+            "boxen": "^3.0.0",
+            "chalk": "^2.0.1",
+            "configstore": "^4.0.0",
+            "has-yarn": "^2.1.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^3.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.6.0",
+        "osenv": "^0.1.5",
+        "semver": "^5.5.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "npm-packlist": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
+    "npm-pick-manifest": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+      "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "npm-registry-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.0.tgz",
+      "integrity": "sha512-Jllq35Jag8dtv0M17ue74XtdQTyqKzuAYGiX9mAjOhkmNjib3bBUgK6mUY61+AHnXeSRobQkpY3/xIOS/omptw==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.3.4",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "npm-package-arg": "^6.1.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -19002,6 +20132,22 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -19040,6 +20186,102 @@
         "semver": "^5.1.0"
       }
     },
+    "pacote": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.4.tgz",
+      "integrity": "sha512-nWr0ari6E+apbdoN0hToTKZElO5h4y8DGFa2pyNA5GQIdcP0imC96bA0bbPw1gpeguVIiUgHHaAlq/6xfPp8Qw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.3",
+        "cacache": "^12.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-registry-fetch": "^4.0.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -19053,6 +20295,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+      "dev": true
+    },
+    "parse-code-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
+      "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==",
       "dev": true
     },
     "parse-headers": {
@@ -19082,6 +20330,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -19229,6 +20483,85 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "prettier-plugin-solidity": {
+      "version": "1.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.27.tgz",
+      "integrity": "sha512-Xd5krR4z0briiuwVx9s/SSv5/5ryD92lF7dzWtYLA1wWi8I8tbUa3vl37zxHp8r3sJ//FvR+IY4awwzTlshjtQ==",
+      "dev": true,
+      "requires": {
+        "dir-to-object": "^2.0.0",
+        "emoji-regex": "^8.0.0",
+        "escape-string-regexp": "^1.0.5",
+        "extract-comments": "^1.1.0",
+        "prettier": "^1.15.3",
+        "semver": "^6.1.2",
+        "solidity-parser-antlr": "^0.4.5",
+        "string-width": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        },
+        "solidity-parser-antlr": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.7.tgz",
+          "integrity": "sha512-iVjNhgqkXw+o+0E+xoLcji+3KuXLe8Rm8omUuVGhsV14+ZsTwQ70nhBRXg8O3t9xwdS0iST1q9NJ5IqHnqpWkA==",
+          "dev": true,
+          "requires": {
+            "npm-check-updates": "^3.1.11"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+              "dev": true
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -19259,6 +20592,22 @@
         "asap": "~2.0.6"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "dev": true,
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
     "promise-to-callback": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
@@ -19266,6 +20615,25 @@
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
+      }
+    },
+    "prompts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+      "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.2",
+        "sisteransi": "^1.0.0"
+      }
+    },
+    "protoduck": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+      "dev": true,
+      "requires": {
+        "genfun": "^5.0.0"
       }
     },
     "prr": {
@@ -19293,10 +20661,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -19342,6 +20720,59 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "rc-config-loader": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.4.tgz",
+      "integrity": "sha512-k06UzRbYDWgF4Mc/YrsZsmzSpDLuHoThJxep+vq5H09hiX8rbA5Ue/Ra0dwWm5MQvWYW4YBXgA186inNxuxidQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "js-yaml": "^3.12.0",
+        "json5": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "object-keys": "^1.0.12",
+        "path-exists": "^3.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
         }
       }
     },
@@ -19571,6 +21002,28 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
+    "requireg": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
+      "integrity": "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==",
+      "dev": true,
+      "requires": {
+        "nested-error-stacks": "~2.0.1",
+        "rc": "~1.2.7",
+        "resolve": "~1.7.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -19590,6 +21043,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -19613,6 +21075,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
@@ -19662,6 +21130,15 @@
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1"
       }
     },
     "rustbn.js": {
@@ -19758,6 +21235,12 @@
       "requires": {
         "semver": "^5.0.3"
       }
+    },
+    "semver-utils": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.4.tgz",
+      "integrity": "sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -19858,6 +21341,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "sisteransi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.2.tgz",
+      "integrity": "sha512-ZcYcZcT69nSLAR2oLN2JwNmLkJEKGooFMCdvOkFrToUt/WfcRWqhIg4P4KwY4dmLbuyXIx4o4YmPsvMRJYJd/w==",
+      "dev": true
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -19881,6 +21370,12 @@
           "dev": true
         }
       }
+    },
+    "smart-buffer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -19983,6 +21478,37 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "4.0.2"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
           }
         }
       }
@@ -20094,6 +21620,63 @@
         }
       }
     },
+    "solhint": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-2.1.2.tgz",
+      "integrity": "sha512-ryJrxNyy7pfx5724HxMtsDFrYLmei02ihHe+dRZL67sFWXInbrHXY1jItNNH3qlj5KYTdgSmBC6PRvHcIv0eAA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "antlr4": "4.7.1",
+        "commander": "2.18.0",
+        "cosmiconfig": "^5.0.7",
+        "eslint": "^5.6.0",
+        "fast-diff": "^1.1.2",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.6",
+        "js-yaml": "^3.12.0",
+        "lodash": "^4.17.11",
+        "prettier": "^1.14.3",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+          "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        }
+      }
+    },
+    "solhint-plugin-prettier": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.3.tgz",
+      "integrity": "sha512-kdg1c7d5/X/RKTBS9AskwAKOZLpFhwUBelwjrUq43EQXOLd2HR81WvENZWcVNmzewiPTEOoZo3CqqE/Hy/84WQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "solidity-parser-antlr": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.15.tgz",
@@ -20137,6 +21720,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spawn-please": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/spawn-please/-/spawn-please-0.3.0.tgz",
+      "integrity": "sha1-2zOOxM/2Orxp8dDgjO6euL69nRE=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -20199,6 +21788,15 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -20222,6 +21820,22 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "strict-uri-encode": {
@@ -20405,6 +22019,29 @@
         }
       }
     },
+    "tar": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
@@ -20542,6 +22179,12 @@
         }
       }
     },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
+    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -20670,6 +22313,12 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -20778,6 +22427,24 @@
             "to-object-path": "^0.3.0"
           }
         }
+      }
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
@@ -20938,6 +22605,15 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "^1.0.3"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:gasreport": "GASREPORT=true npm run test",
     "compile": "truffle compile && truffle compile spuriousDragon",
     "flatten": "bash flatten.sh",
+    "lint": "npm run lint:js && npm run lint:sol",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "flatten": "bash flatten.sh",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
+    "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
+    "lint:sol:prettier:fix": "prettier --write **/*.sol",
     "watch-tests": "./node_modules/.bin/nodemon ./node_modules/.bin/truffle test --network test",
     "coverage": "SOLIDITY_COVERAGE=true scripts/test.sh"
   },
@@ -39,6 +41,9 @@
     "eth-gas-reporter": "^0.1.12",
     "nodemon": "^1.17.3",
     "prettier": "^1.17.1",
+    "prettier-plugin-solidity": "^1.0.0-alpha.27",
+    "solhint": "^2.1.2",
+    "solhint-plugin-prettier": "0.0.3",
     "truffle-flattener": "^1.2.3"
   }
 }

--- a/test/mockContracts/ERC677BridgeTokenRewardableMock.sol
+++ b/test/mockContracts/ERC677BridgeTokenRewardableMock.sol
@@ -1,15 +1,12 @@
 pragma solidity 0.4.24;
 
-import '../../contracts/ERC677BridgeTokenRewardable.sol';
-
+import "../../contracts/ERC677BridgeTokenRewardable.sol";
 
 contract ERC677BridgeTokenRewardableMock is ERC677BridgeTokenRewardable {
-
-    constructor(
-        string _name,
-        string _symbol,
-        uint8 _decimals
-    ) public ERC677BridgeTokenRewardable(_name, _symbol, _decimals) {}
+    constructor(string _name, string _symbol, uint8 _decimals)
+        public
+        ERC677BridgeTokenRewardable(_name, _symbol, _decimals)
+    {}
 
     function setBlockRewardContractMock(address _blockRewardContract) public {
         blockRewardContract = _blockRewardContract;

--- a/test/mockContracts/NoReturnTransferTokenMock.sol
+++ b/test/mockContracts/NoReturnTransferTokenMock.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-
 contract NoReturnTransferTokenMock {
     using SafeMath for uint256;
 

--- a/test/testContracts/ERC677ReceiverTest.sol
+++ b/test/testContracts/ERC677ReceiverTest.sol
@@ -2,14 +2,13 @@ pragma solidity ^0.4.19;
 
 import "../../contracts/interfaces/ERC677Receiver.sol";
 
-
 contract ERC677ReceiverTest is ERC677Receiver {
     address public from;
-    uint public value;
+    uint256 public value;
     bytes public data;
-    uint public someVar = 0;
+    uint256 public someVar = 0;
 
-    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns(bool) {
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns (bool) {
         from = _from;
         value = _value;
         data = _data;
@@ -17,7 +16,7 @@ contract ERC677ReceiverTest is ERC677Receiver {
         return true;
     }
 
-    function doSomething(uint _value) public {
+    function doSomething(uint256 _value) public {
         someVar = _value;
     }
 }

--- a/test/testContracts/ForeignBridgeV2.sol
+++ b/test/testContracts/ForeignBridgeV2.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.4.19;
 
-
 import "../../contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol";
-
 
 interface OwnableToken {
     function transferOwnership(address) external;

--- a/test/testContracts/RevertFallback.sol
+++ b/test/testContracts/RevertFallback.sol
@@ -1,12 +1,9 @@
 pragma solidity 0.4.24;
 
-
 contract RevertFallback {
-    function () public payable {
+    function() public payable {
         revert();
     }
 
-    function receiveEth() public payable {
-
-    }
+    function receiveEth() public payable {}
 }

--- a/test/testContracts/oldBlockReward.sol
+++ b/test/testContracts/oldBlockReward.sol
@@ -1,8 +1,7 @@
 pragma solidity 0.4.24;
 
 contract oldBlockReward {
-
-    function bridgesAllowedLength() external view returns(uint256) {
+    function bridgesAllowedLength() external view returns (uint256) {
         return 3;
     }
 }


### PR DESCRIPTION
This PR adds [Solhint](https://github.com/protofire/solhint) solidity linter and prettier pluging for solidity.

I used the recommended config and disabled some rules to match our contracts needs.
Applied the style fixes from prettier and fixes for solhint warnings.

Added npm script to run and fix the errors from solhint/prettier and also updated travis to run lint script for js and for solidity files too.