### PR TITLE
Slightly optimize the `ERC677BridgeTokenRewardable.mintReward` function

### DIFF
--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -35,7 +35,8 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
     }
 
     function mintReward(address[] _receivers, uint256[] _rewards) external onlyBlockRewardContract {
-        for (uint256 i = 0; i < _receivers.length; i++) {
+        uint256 receiversLength = _receivers.length;
+        for (uint256 i = 0; i < receiversLength; i++) {
             uint256 amount = _rewards[i];
 
             if (amount == 0) continue;


### PR DESCRIPTION
`_receivers.length` was taken out the `for` loop to optimize the `mintReward` function a bit because that value was copied from `calldata` to `memory` on every loop iteration.