### PR TITLE
Fix random method visibility in BaseFeeManager

### DIFF
--- a/contracts/test/FeeManagerMock.sol
+++ b/contracts/test/FeeManagerMock.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.4.24;
+
+import "../upgradeable_contracts/BaseFeeManager.sol";
+
+contract FeeManagerMock is BaseFeeManager {
+    function distributeFeeFromAffirmation(uint256 _fee) external {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function distributeFeeFromSignatures(uint256 _fee) external {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function getFeeManagerMode() external pure returns (bytes4) {
+        return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
+    }
+
+    function randomTest(uint256 _count) external view returns (uint256) {
+        return super.random(_count);
+    }
+}

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -51,7 +51,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
 
     function getFeeManagerMode() external pure returns (bytes4);
 
-    function random(uint256 _count) public view returns (uint256) {
+    function random(uint256 _count) internal view returns (uint256) {
         return uint256(blockhash(block.number.sub(1))) % _count;
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
-    "lint:sol:prettier:fix": "prettier --write **/*.sol",
+    "lint:sol:prettier:fix": "prettier --write \"contracts/**/*.sol\"",
     "watch-tests": "./node_modules/.bin/nodemon ./node_modules/.bin/truffle test --network test",
     "coverage": "SOLIDITY_COVERAGE=true scripts/test.sh"
   },

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -6,6 +6,7 @@ const OldBlockReward = artifacts.require('oldBlockReward')
 const RewardableValidators = artifacts.require('RewardableValidators.sol')
 const FeeManagerErcToNative = artifacts.require('FeeManagerErcToNative.sol')
 const FeeManagerErcToNativePOSDAO = artifacts.require('FeeManagerErcToNativePOSDAO')
+const FeeManagerMock = artifacts.require('FeeManagerMock')
 
 const { expect } = require('chai')
 const { ERROR_MSG, ZERO_ADDRESS, toBN } = require('../setup')
@@ -2160,14 +2161,14 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
   describe('#FeeManager_random', async () => {
     it('should return value between 0 and 3', async () => {
       // Given
-      const feeManager = await FeeManagerErcToNative.new()
+      const feeManager = await FeeManagerMock.new()
 
       for (let i = 0; i < 10; i++) {
         // send Tx to generate new blocks
         await feeManager.setHomeFee(0).should.be.fulfilled
 
         // When
-        const result = await feeManager.random(3)
+        const result = await feeManager.randomTest(3)
 
         // Then
         expect(result).to.be.bignumber.gte(ZERO)


### PR DESCRIPTION
Closes #245 

- Updated `random` method visibility
- Added `FeeManagerMock` to explicitly test that method
- Fixed `lint:sol:prettier:fix` npm script