### PR TITLE
Fix EternalStorageProxy inheritance

### DIFF
--- a/contracts/upgradeability/EternalStorageProxy.sol
+++ b/contracts/upgradeability/EternalStorageProxy.sol
@@ -10,4 +10,4 @@ import "./OwnedUpgradeabilityProxy.sol";
  * authorization control functionalities
  */
 // solhint-disable-next-line no-empty-blocks
-contract EternalStorageProxy is OwnedUpgradeabilityProxy, EternalStorage {}
+contract EternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {}


### PR DESCRIPTION
The layout of the state variables between the `EternalStorageProxy` and implementation contracts were inconsistent. Reading a value of `EternalStorage` from the proxy could lead to read an incorrect value. 

This PR fixes the inheritance and now `EternalStorageProxy` has the same order of the inherited contracts as `ClassicEternalStorageProxy`