### PR TITLE
Add parameter check in setDailyLimit and setExecutionDailyLimit methods

### DIFF
--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -85,6 +85,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function setDailyLimit(uint256 _dailyLimit) external onlyOwner {
+        require(_dailyLimit > maxPerTx() || _dailyLimit == 0);
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         emit DailyLimitChanged(_dailyLimit);
     }
@@ -94,6 +95,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function setExecutionDailyLimit(uint256 _dailyLimit) external onlyOwner {
+        require(_dailyLimit > executionMaxPerTx() || _dailyLimit == 0);
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _dailyLimit;
         emit ExecutionDailyLimitChanged(_dailyLimit);
     }

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -783,10 +783,16 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       initialExecutionDailyLimit.should.be.bignumber.not.equal(newValue)
 
       await homeContract.setExecutionDailyLimit(newValue, { from: authorities[0] }).should.be.rejectedWith(ERROR_MSG)
-      await homeContract.setExecutionDailyLimit(newValue, { from: owner }).should.be.fulfilled
+      await homeContract.setExecutionDailyLimit('2', { from: owner }).should.be.rejectedWith(ERROR_MSG)
 
-      const executionDailyLimit = await homeContract.executionDailyLimit()
-      executionDailyLimit.should.be.bignumber.equal(newValue)
+      await homeContract.setExecutionDailyLimit(newValue, { from: owner }).should.be.fulfilled
+      expect(await homeContract.executionDailyLimit()).to.be.bignumber.equal(newValue)
+
+      await homeContract.setExecutionDailyLimit(0, { from: owner }).should.be.fulfilled
+      expect(await homeContract.executionDailyLimit()).to.be.bignumber.equal(ZERO)
+
+      await homeContract.setExecutionDailyLimit(newValue, { from: owner }).should.be.fulfilled
+      expect(await homeContract.executionDailyLimit()).to.be.bignumber.equal(newValue)
     })
   })
 

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -284,12 +284,24 @@ contract('HomeBridge', async accounts => {
 
       await homeContract.setMaxPerTx(3, { from: owner }).should.be.rejectedWith(ERROR_MSG)
     })
-
     it('#setMinPerTx allows to set only to owner and cannot be more than daily limit and should be less than maxPerTx', async () => {
       await homeContract.setMinPerTx(1, { from: authorities[0] }).should.be.rejectedWith(ERROR_MSG)
       await homeContract.setMinPerTx(1, { from: owner }).should.be.fulfilled
 
       await homeContract.setMinPerTx(2, { from: owner }).should.be.rejectedWith(ERROR_MSG)
+    })
+    it('#setDailyLimit allow to set by owner and should be greater than maxPerTx or zero', async () => {
+      await homeContract.setDailyLimit(4, { from: authorities[0] }).should.be.rejectedWith(ERROR_MSG)
+      await homeContract.setDailyLimit(2, { from: owner }).should.be.rejectedWith(ERROR_MSG)
+
+      await homeContract.setDailyLimit(4, { from: owner }).should.be.fulfilled
+      expect(await homeContract.dailyLimit()).to.be.bignumber.equal('4')
+
+      await homeContract.setDailyLimit(0, { from: owner }).should.be.fulfilled
+      expect(await homeContract.dailyLimit()).to.be.bignumber.equal(ZERO)
+
+      await homeContract.setDailyLimit(4, { from: owner }).should.be.fulfilled
+      expect(await homeContract.dailyLimit()).to.be.bignumber.equal('4')
     })
   })
 


### PR DESCRIPTION
Add parameter check in `setDailyLimit` and `setExecutionDailyLimit` methods to maintain consistency of `minPerTx < MaxPerTx < dailyLimit` and `executionMaxPerTx < executionDailyLimit`.

`dailyLimit` and `executionDailyLimit` can still be set to `0` if needed to stop bridge operations.