### PR TITLE
Check proxy upgrade contract code

### DIFF
--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -8,8 +8,6 @@ import "./interfaces/IBurnableMintableERC677Token.sol";
 import "./upgradeable_contracts/Claimable.sol";
 
 contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, BurnableToken, MintableToken, Claimable {
-    using AddressUtils for address;
-
     address public bridgeContract;
 
     event ContractFallbackCallFailed(address from, address to, uint256 value);
@@ -19,7 +17,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
     }
 
     function setBridgeContract(address _bridgeContract) external onlyOwner {
-        require(_bridgeContract.isContract());
+        require(AddressUtils.isContract(_bridgeContract));
         bridgeContract = _bridgeContract;
     }
 
@@ -32,7 +30,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
         require(superTransfer(_to, _value));
         emit Transfer(msg.sender, _to, _value, _data);
 
-        if (_to.isContract()) {
+        if (AddressUtils.isContract(_to)) {
             require(contractFallback(msg.sender, _to, _value, _data));
         }
         return true;
@@ -59,7 +57,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
     }
 
     function callAfterTransfer(address _from, address _to, uint256 _value) internal {
-        if (_to.isContract() && !contractFallback(_from, _to, _value, new bytes(0))) {
+        if (AddressUtils.isContract(_to) && !contractFallback(_from, _to, _value, new bytes(0))) {
             require(_to != bridgeContract);
             emit ContractFallbackCallFailed(_from, _to, _value);
         }

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -11,12 +11,12 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
     }
 
     function setBlockRewardContract(address _blockRewardContract) external onlyOwner {
-        require(isContract(_blockRewardContract));
+        require(_blockRewardContract.isContract());
         blockRewardContract = _blockRewardContract;
     }
 
     function setStakingContract(address _stakingContract) external onlyOwner {
-        require(isContract(_stakingContract));
+        require(_stakingContract.isContract());
         stakingContract = _stakingContract;
     }
 

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -11,12 +11,12 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
     }
 
     function setBlockRewardContract(address _blockRewardContract) external onlyOwner {
-        require(_blockRewardContract.isContract());
+        require(AddressUtils.isContract(_blockRewardContract));
         blockRewardContract = _blockRewardContract;
     }
 
     function setStakingContract(address _stakingContract) external onlyOwner {
-        require(_stakingContract.isContract());
+        require(AddressUtils.isContract(_stakingContract));
         stakingContract = _stakingContract;
     }
 

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -9,8 +9,6 @@ import "./UpgradeabilityStorage.sol";
  * @dev This contract represents a proxy where the implementation address to which it will delegate can be upgraded
  */
 contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
-    using AddressUtils for address;
-
     /**
     * @dev This event will be emitted every time the implementation gets upgraded
     * @param version representing the version name of the upgraded implementation
@@ -25,7 +23,7 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
     */
     function _upgradeTo(uint256 version, address implementation) internal {
         require(_implementation != implementation);
-        require(implementation.isContract());
+        require(AddressUtils.isContract(implementation));
         require(version > _version);
         _version = version;
         _implementation = implementation;

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.24;
 
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "./Proxy.sol";
 import "./UpgradeabilityStorage.sol";
 
@@ -8,6 +9,8 @@ import "./UpgradeabilityStorage.sol";
  * @dev This contract represents a proxy where the implementation address to which it will delegate can be upgraded
  */
 contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
+    using AddressUtils for address;
+
     /**
     * @dev This event will be emitted every time the implementation gets upgraded
     * @param version representing the version name of the upgraded implementation
@@ -22,6 +25,7 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
     */
     function _upgradeTo(uint256 version, address implementation) internal {
         require(_implementation != implementation);
+        require(implementation.isContract());
         require(version > _version);
         _version = version;
         _implementation = implementation;

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -11,7 +11,6 @@ import "./Claimable.sol";
 
 contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claimable {
     using SafeMath for uint256;
-    using AddressUtils for address;
 
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -1,14 +1,17 @@
 pragma solidity 0.4.24;
+
 import "../interfaces/IBridgeValidators.sol";
 import "./Upgradeable.sol";
 import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "./Validatable.sol";
 import "./Ownable.sol";
 import "./Claimable.sol";
 
 contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claimable {
     using SafeMath for uint256;
+    using AddressUtils for address;
 
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
@@ -129,13 +132,5 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function claimTokens(address _token, address _to) public onlyIfUpgradeabilityOwner validAddress(_to) {
         claimValues(_token, _to);
-    }
-
-    function isContract(address _addr) internal view returns (bool) {
-        uint256 length;
-        assembly {
-            length := extcodesize(_addr)
-        }
-        return length > 0;
     }
 }

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -9,7 +9,7 @@ contract ERC677Bridge is BasicBridge {
     }
 
     function setErc677token(address _token) internal {
-        require(_token.isContract());
+        require(AddressUtils.isContract(_token));
         addressStorage[keccak256(abi.encodePacked("erc677token"))] = _token;
     }
 

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -9,7 +9,7 @@ contract ERC677Bridge is BasicBridge {
     }
 
     function setErc677token(address _token) internal {
-        require(isContract(_token));
+        require(_token.isContract());
         addressStorage[keccak256(abi.encodePacked("erc677token"))] = _token;
     }
 

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -1,9 +1,12 @@
 pragma solidity 0.4.24;
 
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "./Ownable.sol";
 import "./FeeTypes.sol";
 
 contract RewardableBridge is Ownable, FeeTypes {
+    using AddressUtils for address;
+
     event FeeDistributedFromAffirmation(uint256 feeAmount, bytes32 indexed transactionHash);
     event FeeDistributedFromSignatures(uint256 feeAmount, bytes32 indexed transactionHash);
 
@@ -46,21 +49,13 @@ contract RewardableBridge is Ownable, FeeTypes {
     }
 
     function setFeeManagerContract(address _feeManager) external onlyOwner {
-        require(_feeManager == address(0) || isContract(_feeManager));
+        require(_feeManager == address(0) || _feeManager.isContract());
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
     }
 
     function _setFee(address _feeManager, uint256 _fee, bytes32 _feeType) internal {
         string memory method = _feeType == HOME_FEE ? "setHomeFee(uint256)" : "setForeignFee(uint256)";
         require(_feeManager.delegatecall(abi.encodeWithSignature(method, _fee)));
-    }
-
-    function isContract(address _addr) internal view returns (bool) {
-        uint256 length;
-        assembly {
-            length := extcodesize(_addr)
-        }
-        return length > 0;
     }
 
     function calculateFee(uint256 _value, bool _recover, address _impl, bytes32 _feeType)

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -5,8 +5,6 @@ import "./Ownable.sol";
 import "./FeeTypes.sol";
 
 contract RewardableBridge is Ownable, FeeTypes {
-    using AddressUtils for address;
-
     event FeeDistributedFromAffirmation(uint256 feeAmount, bytes32 indexed transactionHash);
     event FeeDistributedFromSignatures(uint256 feeAmount, bytes32 indexed transactionHash);
 
@@ -49,7 +47,7 @@ contract RewardableBridge is Ownable, FeeTypes {
     }
 
     function setFeeManagerContract(address _feeManager) external onlyOwner {
-        require(_feeManager == address(0) || _feeManager.isContract());
+        require(_feeManager == address(0) || AddressUtils.isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -15,7 +15,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         address _owner
     ) internal {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_requiredBlockConfirmations != 0);
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -15,7 +15,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -4,8 +4,6 @@ import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
-    using AddressUtils for address;
-
     function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
@@ -15,7 +13,7 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
     }
 
     function setBlockRewardContract(address _blockReward) external {
-        require(_blockReward.isContract());
+        require(AddressUtils.isContract(_blockReward));
 
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,
         // call a specific method from the contract that should return a specific value

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -1,8 +1,11 @@
 pragma solidity 0.4.24;
 
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
+    using AddressUtils for address;
+
     function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
@@ -12,7 +15,7 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
     }
 
     function setBlockRewardContract(address _blockReward) external {
-        require(isContract(_blockReward));
+        require(_blockReward.isContract());
 
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,
         // call a specific method from the contract that should return a specific value
@@ -30,13 +33,5 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
     function distributeFeeFromBlockReward(uint256 _fee) internal {
         IBlockReward blockReward = _blockRewardContract();
         blockReward.addBridgeTokenFeeReceivers(_fee);
-    }
-
-    function isContract(address _addr) internal view returns (bool) {
-        uint256 length;
-        assembly {
-            length := extcodesize(_addr)
-        }
-        return length > 0;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -31,7 +31,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
     }
 
     function setErc20token(address _token) internal {
-        require(isContract(_token));
+        require(_token.isContract());
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -31,7 +31,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
     }
 
     function setErc20token(address _token) internal {
-        require(_token.isContract());
+        require(AddressUtils.isContract(_token));
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -110,7 +110,7 @@ contract HomeBridgeErcToErc is
             _foreignMaxPerTx,
             _owner
         );
-        require(_feeManager.isContract());
+        require(AddressUtils.isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -129,7 +129,7 @@ contract HomeBridgeErcToErc is
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -110,7 +110,7 @@ contract HomeBridgeErcToErc is
             _foreignMaxPerTx,
             _owner
         );
-        require(isContract(_feeManager));
+        require(_feeManager.isContract());
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -129,7 +129,7 @@ contract HomeBridgeErcToErc is
         address _owner
     ) internal {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -19,7 +19,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         address _owner
     ) external returns (bool) {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
@@ -60,7 +60,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
     }
 
     function setErc20token(address _token) private {
-        require(_token.isContract());
+        require(AddressUtils.isContract(_token));
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -19,7 +19,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         address _owner
     ) external returns (bool) {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_requiredBlockConfirmations != 0);
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
@@ -60,7 +60,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
     }
 
     function setErc20token(address _token) private {
-        require(isContract(_token));
+        require(_token.isContract());
         addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -93,7 +93,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
             _foreignMaxPerTx,
             _owner
         );
-        require(_feeManager.isContract());
+        require(AddressUtils.isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -115,7 +115,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
     }
 
     function setBlockRewardContract(address _blockReward) external onlyOwner {
-        require(_blockReward.isContract());
+        require(AddressUtils.isContract(_blockReward));
 
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,
         // call a specific method from the contract that should return a specific value
@@ -143,10 +143,10 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
-        require(_blockReward == address(0) || _blockReward.isContract());
+        require(_blockReward == address(0) || AddressUtils.isContract(_blockReward));
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -93,7 +93,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
             _foreignMaxPerTx,
             _owner
         );
-        require(isContract(_feeManager));
+        require(_feeManager.isContract());
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -115,7 +115,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
     }
 
     function setBlockRewardContract(address _blockReward) external onlyOwner {
-        require(isContract(_blockReward));
+        require(_blockReward.isContract());
 
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,
         // call a specific method from the contract that should return a specific value
@@ -143,10 +143,10 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         address _owner
     ) internal {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
-        require(_blockReward == address(0) || isContract(_blockReward));
+        require(_blockReward == address(0) || _blockReward.isContract());
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -70,7 +70,7 @@ contract ForeignBridgeNativeToErc is
             _homeMaxPerTx,
             _owner
         );
-        require(_feeManager.isContract());
+        require(AddressUtils.isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         setInitialize();
@@ -98,7 +98,7 @@ contract ForeignBridgeNativeToErc is
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_requiredBlockConfirmations > 0);
         require(_foreignGasPrice > 0);

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -70,7 +70,7 @@ contract ForeignBridgeNativeToErc is
             _homeMaxPerTx,
             _owner
         );
-        require(isContract(_feeManager));
+        require(_feeManager.isContract());
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         setInitialize();
@@ -98,7 +98,7 @@ contract ForeignBridgeNativeToErc is
         address _owner
     ) internal {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_requiredBlockConfirmations > 0);
         require(_foreignGasPrice > 0);

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -76,7 +76,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
             _foreignMaxPerTx,
             _owner
         );
-        require(isContract(_feeManager));
+        require(_feeManager.isContract());
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -100,7 +100,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         address _owner
     ) internal {
         require(!isInitialized());
-        require(isContract(_validatorContract));
+        require(_validatorContract.isContract());
         require(_homeGasPrice > 0);
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -76,7 +76,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
             _foreignMaxPerTx,
             _owner
         );
-        require(_feeManager.isContract());
+        require(AddressUtils.isContract(_feeManager));
         addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
@@ -100,7 +100,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_validatorContract.isContract());
+        require(AddressUtils.isContract(_validatorContract));
         require(_homeGasPrice > 0);
         require(_requiredBlockConfirmations > 0);
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -107,6 +107,8 @@ contract('HomeBridge', async accounts => {
       const data = homeContract.contract.methods
         .initialize(validatorContract.address, '3', '2', '1', gasPrice, requireBlockConfirmations, '3', '2', owner)
         .encodeABI()
+      await storageProxy.upgradeTo('1', accounts[5]).should.be.rejectedWith(ERROR_MSG)
+      await storageProxy.upgradeToAndCall('1', accounts[5], data).should.be.rejectedWith(ERROR_MSG)
       await storageProxy.upgradeToAndCall('1', homeContract.address, data).should.be.fulfilled
       const finalContract = await HomeBridge.at(storageProxy.address)
 


### PR DESCRIPTION
The default behavior of `delegatecall` returns `true` if the contract does not exist. Because of that, it makes sense to check `extcodesize > 0` when setting the implementation contract.

We have repeated implementations of the method `isContract` in different contracts. I removed all the implementation and used the `openzeppelin-solidity` implementation of this method which is exactly the same.

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/0e65947efbffc592cffea8c2ae9d3b8e11659854/contracts/AddressUtils.sol#L16-L27