### PR TITLE
Improve initialize method's gas usage in validator contracts

### DIFF
--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -30,10 +30,10 @@ contract BridgeValidators is BaseBridgeValidators {
                 setNextValidator(_initialValidators[i - 1], _initialValidators[i]);
             }
 
-            setValidatorCount(validatorCount().add(1));
             emit ValidatorAdded(_initialValidators[i]);
         }
 
+        setValidatorCount(_initialValidators.length);
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         setInitialize();

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -34,11 +34,11 @@ contract RewardableValidators is BaseBridgeValidators {
                 setNextValidator(_initialValidators[i - 1], _initialValidators[i]);
             }
 
-            setValidatorCount(validatorCount().add(1));
             setValidatorRewardAddress(_initialValidators[i], _initialRewards[i]);
             emit ValidatorAdded(_initialValidators[i]);
         }
 
+        setValidatorCount(_initialValidators.length);
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         setInitialize();


### PR DESCRIPTION
Moved `setValidatorCount` call out of the `for` loop to save gas