### PR TITLE
Update ERC677Bridge to inherit from ERC677Receiver

### DIFF
--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -2,8 +2,9 @@ pragma solidity 0.4.24;
 
 import "./BasicBridge.sol";
 import "../interfaces/ERC677.sol";
+import "../interfaces/ERC677Receiver.sol";
 
-contract ERC677Bridge is BasicBridge {
+contract ERC677Bridge is BasicBridge, ERC677Receiver {
     function erc677token() public view returns (ERC677) {
         return ERC677(addressStorage[keccak256(abi.encodePacked("erc677token"))]);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -3,14 +3,12 @@ pragma solidity 0.4.24;
 import "../../libraries/Message.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
-import "../../interfaces/ERC677Receiver.sol";
 import "../BasicHomeBridge.sol";
 import "../OverdrawManagement.sol";
 import "./RewardableHomeBridgeErcToErc.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 
 contract HomeBridgeErcToErc is
-    ERC677Receiver,
     EternalStorage,
     BasicHomeBridge,
     ERC677BridgeForBurnableMintableToken,

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -1,14 +1,12 @@
 pragma solidity 0.4.24;
 
 import "../../interfaces/IBurnableMintableERC677Token.sol";
-import "../../interfaces/ERC677Receiver.sol";
 import "../BasicForeignBridge.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 import "./RewardableForeignBridgeNativeToErc.sol";
 
 contract ForeignBridgeNativeToErc is
-    ERC677Receiver,
     BasicForeignBridge,
     ERC677BridgeForBurnableMintableToken,
     RewardableForeignBridgeNativeToErc


### PR DESCRIPTION
Since `ERC677Bridge` implements `ERC677Receiver` interface, it makes sense that `ERC677Bridge` inherit directly from that contract