### PR TITLE
Minor fixes on contracts

### DIFF
--- a/contracts/interfaces/IBurnableMintableERC677Token.sol
+++ b/contracts/interfaces/IBurnableMintableERC677Token.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 import "../interfaces/ERC677.sol";
 
 contract IBurnableMintableERC677Token is ERC677 {
-    function mint(address, uint256) public returns (bool);
+    function mint(address _to, uint256 _amount) public returns (bool);
     function burn(uint256 _value) public;
     function claimTokens(address _token, address _to) public;
 }

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -13,7 +13,7 @@ contract UpgradeabilityStorage {
 
     /**
     * @dev Tells the version name of the current implementation
-    * @return string representing the name of the current version
+    * @return uint256 representing the name of the current version
     */
     function version() external view returns (uint256) {
         return _version;

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -1,14 +1,12 @@
 pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
 import "./BasicBridge.sol";
 
 contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge {
-    using SafeMath for uint256;
     /// triggered when relay of deposit from HomeBridge is complete
     event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
     function executeSignatures(uint8[] vs, bytes32[] rs, bytes32[] ss, bytes message) external {


### PR DESCRIPTION
This PR includes 3 minor fixes:

-  Removed unused `SafeMath` in `BasicForeignBridge`
-  Add name to mint parameters for consistency in `IBurnableMintableERC677Token`
- Fix return comment in `version` method of `UpgradeabilityStorage` contract