### PR TITLE
Move mappings key to constants

### DIFF
--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -12,8 +12,6 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
 
     event ContractFallbackCallFailed(address from, address to, uint256 value);
 
-    bytes4 internal constant ON_TOKEN_TRANSFER = 0xa4c0ed36; // onTokenTransfer(address,uint256,bytes)
-
     constructor(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -67,7 +65,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
     }
 
     function contractFallback(address _from, address _to, uint256 _value, bytes _data) private returns (bool) {
-        return _to.call(abi.encodeWithSelector(ON_TOKEN_TRANSFER, _from, _value, _data));
+        return _to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256,bytes)", _from, _value, _data));
     }
 
     function finishMinting() public returns (bool) {

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -12,6 +12,8 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
 
     event ContractFallbackCallFailed(address from, address to, uint256 value);
 
+    bytes4 internal constant ON_TOKEN_TRANSFER = 0xa4c0ed36; // onTokenTransfer(address,uint256,bytes)
+
     constructor(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -65,7 +67,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
     }
 
     function contractFallback(address _from, address _to, uint256 _value, bytes _data) private returns (bool) {
-        return _to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256,bytes)", _from, _value, _data));
+        return _to.call(abi.encodeWithSelector(ON_TOKEN_TRANSFER, _from, _value, _data));
     }
 
     function finishMinting() public returns (bool) {

--- a/contracts/mocks/BlockReward.sol
+++ b/contracts/mocks/BlockReward.sol
@@ -11,6 +11,7 @@ contract BlockReward {
     uint256 public feeAmount = 0;
     mapping(bytes32 => uint256) internal uintStorage;
     bytes32 internal constant MINTED_TOTALLY_BY_BRIDGE = "mintedTotallyByBridge";
+    bytes4 internal constant MINT_REWARD = 0xe2f764a3; // mintReward(address[],uint256[])
     address public token;
 
     function() external payable {
@@ -86,7 +87,7 @@ contract BlockReward {
             rewards[i] = feeToDistribute;
         }
 
-        require(token.call(abi.encodeWithSignature("mintReward(address[],uint256[])", receivers, rewards)));
+        require(token.call(abi.encodeWithSelector(MINT_REWARD, receivers, rewards)));
     }
 
     function random(uint256 _count) public view returns (uint256) {

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -2,9 +2,9 @@ pragma solidity 0.4.24;
 
 import "./Ownable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "../upgradeability/EternalStorage.sol";
+import "./Initializable.sol";
 
-contract BaseBridgeValidators is EternalStorage, Ownable {
+contract BaseBridgeValidators is Initializable, Ownable {
     using SafeMath for uint256;
 
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
@@ -85,14 +85,6 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
         return _validator != F_ADDR && getNextValidator(_validator) != address(0);
     }
 
-    function isInitialized() public view returns (bool) {
-        return boolStorage[keccak256(abi.encodePacked("isInitialized"))];
-    }
-
-    function deployedAtBlock() external view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
-    }
-
     function getNextValidator(address _address) public view returns (address) {
         return addressStorage[keccak256(abi.encodePacked("validatorsList", _address))];
     }
@@ -107,9 +99,5 @@ contract BaseBridgeValidators is EternalStorage, Ownable {
 
     function setNextValidator(address _prevValidator, address _validator) internal {
         addressStorage[keccak256(abi.encodePacked("validatorsList", _prevValidator))] = _validator;
-    }
-
-    function setInitialize() internal {
-        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = true;
     }
 }

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -9,6 +9,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
 
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
     uint256 internal constant MAX_VALIDATORS = 100;
+    bytes32 internal constant REQUIRED_SIGNATURES = keccak256(abi.encodePacked("requiredSignatures"));
 
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);
@@ -17,7 +18,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
     function setRequiredSignatures(uint256 _requiredSignatures) external onlyOwner {
         require(validatorCount() >= _requiredSignatures);
         require(_requiredSignatures != 0);
-        uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
+        uintStorage[REQUIRED_SIGNATURES] = _requiredSignatures;
         emit RequiredSignaturesChanged(_requiredSignatures);
     }
 
@@ -74,7 +75,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
     }
 
     function requiredSignatures() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("requiredSignatures"))];
+        return uintStorage[REQUIRED_SIGNATURES];
     }
 
     function validatorCount() public view returns (uint256) {

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -10,6 +10,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
     uint256 internal constant MAX_VALIDATORS = 100;
     bytes32 internal constant REQUIRED_SIGNATURES = keccak256(abi.encodePacked("requiredSignatures"));
+    bytes32 internal constant VALIDATOR_COUNT = keccak256(abi.encodePacked("validatorCount"));
 
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);
@@ -79,7 +80,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
     }
 
     function validatorCount() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("validatorCount"))];
+        return uintStorage[VALIDATOR_COUNT];
     }
 
     function isValidator(address _validator) public view returns (bool) {
@@ -95,7 +96,7 @@ contract BaseBridgeValidators is Initializable, Ownable {
     }
 
     function setValidatorCount(uint256 _validatorCount) internal {
-        uintStorage[keccak256(abi.encodePacked("validatorCount"))] = _validatorCount;
+        uintStorage[VALIDATOR_COUNT] = _validatorCount;
     }
 
     function setNextValidator(address _prevValidator, address _validator) internal {

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -13,6 +13,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
 
     // This is not a real fee value but a relative value used to calculate the fee percentage
     uint256 internal constant MAX_FEE = 1 ether;
+    bytes32 internal constant HOME_FEE_STORAGE_KEY = keccak256(abi.encodePacked("homeFee"));
 
     function calculateFee(uint256 _value, bool _recover, bytes32 _feeType) public view returns (uint256) {
         uint256 fee = _feeType == HOME_FEE ? getHomeFee() : getForeignFee();
@@ -29,12 +30,12 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
     }
 
     function setHomeFee(uint256 _fee) external validFee(_fee) {
-        uintStorage[keccak256(abi.encodePacked("homeFee"))] = _fee;
+        uintStorage[HOME_FEE_STORAGE_KEY] = _fee;
         emit HomeFeeUpdated(_fee);
     }
 
     function getHomeFee() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("homeFee"))];
+        return uintStorage[HOME_FEE_STORAGE_KEY];
     }
 
     function setForeignFee(uint256 _fee) external validFee(_fee) {

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -14,6 +14,7 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
     // This is not a real fee value but a relative value used to calculate the fee percentage
     uint256 internal constant MAX_FEE = 1 ether;
     bytes32 internal constant HOME_FEE_STORAGE_KEY = keccak256(abi.encodePacked("homeFee"));
+    bytes32 internal constant FOREIGN_FEE_STORAGE_KEY = keccak256(abi.encodePacked("foreignFee"));
 
     function calculateFee(uint256 _value, bool _recover, bytes32 _feeType) public view returns (uint256) {
         uint256 fee = _feeType == HOME_FEE ? getHomeFee() : getForeignFee();
@@ -39,12 +40,12 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
     }
 
     function setForeignFee(uint256 _fee) external validFee(_fee) {
-        uintStorage[keccak256(abi.encodePacked("foreignFee"))] = _fee;
+        uintStorage[FOREIGN_FEE_STORAGE_KEY] = _fee;
         emit ForeignFeeUpdated(_fee);
     }
 
     function getForeignFee() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("foreignFee"))];
+        return uintStorage[FOREIGN_FEE_STORAGE_KEY];
     }
 
     /* solcov ignore next */

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -19,6 +19,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
+    bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 3, 0);
@@ -49,11 +50,11 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function setTotalSpentPerDay(uint256 _day, uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))] = _value;
+        uintStorage[keccak256(abi.encodePacked(TOTAL_SPENT_PER_DAY, _day))] = _value;
     }
 
     function totalSpentPerDay(uint256 _day) public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))];
+        return uintStorage[keccak256(abi.encodePacked(TOTAL_SPENT_PER_DAY, _day))];
     }
 
     function setTotalExecutedPerDay(uint256 _day, uint256 _value) internal {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -20,6 +20,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
     bytes32 internal constant MIN_PER_TX = keccak256(abi.encodePacked("minPerTx"));
+    bytes32 internal constant MAX_PER_TX = keccak256(abi.encodePacked("maxPerTx"));
 
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
     bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
@@ -73,7 +74,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function maxPerTx() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("maxPerTx"))];
+        return uintStorage[MAX_PER_TX];
     }
 
     function executionMaxPerTx() public view returns (uint256) {
@@ -120,7 +121,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setMaxPerTx(uint256 _maxPerTx) external onlyOwner {
         require(_maxPerTx < dailyLimit());
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
     }
 
     function setMinPerTx(uint256 _minPerTx) external onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -2,14 +2,14 @@ pragma solidity 0.4.24;
 
 import "../interfaces/IBridgeValidators.sol";
 import "./Upgradeable.sol";
-import "../upgradeability/EternalStorage.sol";
+import "./Initializable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "./Validatable.sol";
 import "./Ownable.sol";
 import "./Claimable.sol";
 
-contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claimable {
+contract BasicBridge is Initializable, Validatable, Ownable, Upgradeable, Claimable {
     using SafeMath for uint256;
 
     event GasPriceChanged(uint256 gasPrice);
@@ -52,10 +52,6 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
         return uintStorage[REQUIRED_BLOCK_CONFIRMATIONS];
     }
 
-    function deployedAtBlock() external view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))];
-    }
-
     function setTotalSpentPerDay(uint256 _day, uint256 _value) internal {
         uintStorage[keccak256(abi.encodePacked(TOTAL_SPENT_PER_DAY, _day))] = _value;
     }
@@ -82,14 +78,6 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function executionMaxPerTx() public view returns (uint256) {
         return uintStorage[EXECUTION_MAX_PER_TX];
-    }
-
-    function setInitialize() internal {
-        boolStorage[keccak256(abi.encodePacked("isInitialized"))] = true;
-    }
-
-    function isInitialized() public view returns (bool) {
-        return boolStorage[keccak256(abi.encodePacked("isInitialized"))];
     }
 
     function getCurrentDay() public view returns (uint256) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -23,6 +23,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     bytes32 internal constant MAX_PER_TX = keccak256(abi.encodePacked("maxPerTx"));
     bytes32 internal constant DAILY_LIMIT = keccak256(abi.encodePacked("dailyLimit"));
     bytes32 internal constant EXECUTION_MAX_PER_TX = keccak256(abi.encodePacked("executionMaxPerTx"));
+    bytes32 internal constant EXECUTION_DAILY_LIMIT = keccak256(abi.encodePacked("executionDailyLimit"));
 
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
     bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
@@ -108,12 +109,12 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setExecutionDailyLimit(uint256 _dailyLimit) external onlyOwner {
         require(_dailyLimit > executionMaxPerTx() || _dailyLimit == 0);
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _dailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _dailyLimit;
         emit ExecutionDailyLimitChanged(_dailyLimit);
     }
 
     function executionDailyLimit() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))];
+        return uintStorage[EXECUTION_DAILY_LIMIT];
     }
 
     function setExecutionMaxPerTx(uint256 _maxPerTx) external onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -21,6 +21,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
     bytes32 internal constant MIN_PER_TX = keccak256(abi.encodePacked("minPerTx"));
     bytes32 internal constant MAX_PER_TX = keccak256(abi.encodePacked("maxPerTx"));
+    bytes32 internal constant DAILY_LIMIT = keccak256(abi.encodePacked("dailyLimit"));
 
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
     bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
@@ -96,12 +97,12 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setDailyLimit(uint256 _dailyLimit) external onlyOwner {
         require(_dailyLimit > maxPerTx() || _dailyLimit == 0);
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         emit DailyLimitChanged(_dailyLimit);
     }
 
     function dailyLimit() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("dailyLimit"))];
+        return uintStorage[DAILY_LIMIT];
     }
 
     function setExecutionDailyLimit(uint256 _dailyLimit) external onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -17,18 +17,20 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     event DailyLimitChanged(uint256 newLimit);
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
+    bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
+
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 3, 0);
     }
 
     function setGasPrice(uint256 _gasPrice) external onlyOwner {
         require(_gasPrice > 0);
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;
+        uintStorage[GAS_PRICE] = _gasPrice;
         emit GasPriceChanged(_gasPrice);
     }
 
     function gasPrice() external view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("gasPrice"))];
+        return uintStorage[GAS_PRICE];
     }
 
     function setRequiredBlockConfirmations(uint256 _blockConfirmations) external onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -22,6 +22,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     bytes32 internal constant MIN_PER_TX = keccak256(abi.encodePacked("minPerTx"));
     bytes32 internal constant MAX_PER_TX = keccak256(abi.encodePacked("maxPerTx"));
     bytes32 internal constant DAILY_LIMIT = keccak256(abi.encodePacked("dailyLimit"));
+    bytes32 internal constant EXECUTION_MAX_PER_TX = keccak256(abi.encodePacked("executionMaxPerTx"));
 
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
     bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
@@ -79,7 +80,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function executionMaxPerTx() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))];
+        return uintStorage[EXECUTION_MAX_PER_TX];
     }
 
     function setInitialize() internal {
@@ -117,7 +118,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setExecutionMaxPerTx(uint256 _maxPerTx) external onlyOwner {
         require(_maxPerTx < executionDailyLimit());
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _maxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _maxPerTx;
     }
 
     function setMaxPerTx(uint256 _maxPerTx) external onlyOwner {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -18,6 +18,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
     bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
+    bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 3, 0);
@@ -35,12 +36,12 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setRequiredBlockConfirmations(uint256 _blockConfirmations) external onlyOwner {
         require(_blockConfirmations > 0);
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _blockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _blockConfirmations;
         emit RequiredBlockConfirmationChanged(_blockConfirmations);
     }
 
     function requiredBlockConfirmations() external view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))];
+        return uintStorage[REQUIRED_BLOCK_CONFIRMATIONS];
     }
 
     function deployedAtBlock() external view returns (uint256) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -25,9 +25,6 @@ contract BasicBridge is Initializable, Validatable, Ownable, Upgradeable, Claima
     bytes32 internal constant EXECUTION_MAX_PER_TX = keccak256(abi.encodePacked("executionMaxPerTx"));
     bytes32 internal constant EXECUTION_DAILY_LIMIT = keccak256(abi.encodePacked("executionDailyLimit"));
 
-    bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
-    bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
-
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 3, 0);
     }
@@ -53,19 +50,19 @@ contract BasicBridge is Initializable, Validatable, Ownable, Upgradeable, Claima
     }
 
     function setTotalSpentPerDay(uint256 _day, uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked(TOTAL_SPENT_PER_DAY, _day))] = _value;
+        uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))] = _value;
     }
 
     function totalSpentPerDay(uint256 _day) public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked(TOTAL_SPENT_PER_DAY, _day))];
+        return uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))];
     }
 
     function setTotalExecutedPerDay(uint256 _day, uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked(TOTAL_EXECUTED_PER_DAY, _day))] = _value;
+        uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))] = _value;
     }
 
     function totalExecutedPerDay(uint256 _day) public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked(TOTAL_EXECUTED_PER_DAY, _day))];
+        return uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))];
     }
 
     function minPerTx() public view returns (uint256) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -19,6 +19,8 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
+    bytes32 internal constant MIN_PER_TX = keccak256(abi.encodePacked("minPerTx"));
+
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
     bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
 
@@ -67,7 +69,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function minPerTx() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("minPerTx"))];
+        return uintStorage[MIN_PER_TX];
     }
 
     function maxPerTx() public view returns (uint256) {
@@ -123,7 +125,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
 
     function setMinPerTx(uint256 _minPerTx) external onlyOwner {
         require(_minPerTx < dailyLimit() && _minPerTx < maxPerTx());
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
     }
 
     function withinLimit(uint256 _amount) public view returns (bool) {

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -20,6 +20,7 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
     bytes32 internal constant TOTAL_SPENT_PER_DAY = "totalSpentPerDay";
+    bytes32 internal constant TOTAL_EXECUTED_PER_DAY = "totalExecutedPerDay";
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (2, 3, 0);
@@ -58,11 +59,11 @@ contract BasicBridge is EternalStorage, Validatable, Ownable, Upgradeable, Claim
     }
 
     function setTotalExecutedPerDay(uint256 _day, uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))] = _value;
+        uintStorage[keccak256(abi.encodePacked(TOTAL_EXECUTED_PER_DAY, _day))] = _value;
     }
 
     function totalExecutedPerDay(uint256 _day) public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("totalExecutedPerDay", _day))];
+        return uintStorage[keccak256(abi.encodePacked(TOTAL_EXECUTED_PER_DAY, _day))];
     }
 
     function minPerTx() public view returns (uint256) {

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
 import "./BasicBridge.sol";

--- a/contracts/upgradeable_contracts/BlockRewardBridge.sol
+++ b/contracts/upgradeable_contracts/BlockRewardBridge.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.4.24;
+
+import "../interfaces/IBlockReward.sol";
+import "../upgradeability/EternalStorage.sol";
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
+
+contract BlockRewardBridge is EternalStorage {
+    bytes32 internal constant BLOCK_REWARD_CONTRACT = keccak256(abi.encodePacked("blockRewardContract"));
+
+    function _blockRewardContract() internal view returns (IBlockReward) {
+        return IBlockReward(addressStorage[BLOCK_REWARD_CONTRACT]);
+    }
+
+    function _setBlockRewardContract(address _blockReward) internal {
+        require(AddressUtils.isContract(_blockReward));
+
+        // Before store the contract we need to make sure that it is the block reward contract in actual fact,
+        // call a specific method from the contract that should return a specific value
+        bool isBlockRewardContract = false;
+        if (_blockReward.call(abi.encodeWithSignature("blockRewardContractId()"))) {
+            isBlockRewardContract =
+                IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
+        } else if (_blockReward.call(abi.encodeWithSignature("bridgesAllowedLength()"))) {
+            isBlockRewardContract = IBlockReward(_blockReward).bridgesAllowedLength() != 0;
+        }
+        require(isBlockRewardContract);
+        addressStorage[BLOCK_REWARD_CONTRACT] = _blockReward;
+    }
+}

--- a/contracts/upgradeable_contracts/BlockRewardBridge.sol
+++ b/contracts/upgradeable_contracts/BlockRewardBridge.sol
@@ -6,6 +6,8 @@ import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract BlockRewardBridge is EternalStorage {
     bytes32 internal constant BLOCK_REWARD_CONTRACT = keccak256(abi.encodePacked("blockRewardContract"));
+    bytes4 internal constant BLOCK_REWARD_CONTRACT_ID = 0x2ee57f8d; // blockRewardContractId()
+    bytes4 internal constant BRIDGES_ALLOWED_LENGTH = 0x10f2ee7c; // bridgesAllowedLength()
 
     function _blockRewardContract() internal view returns (IBlockReward) {
         return IBlockReward(addressStorage[BLOCK_REWARD_CONTRACT]);
@@ -17,10 +19,10 @@ contract BlockRewardBridge is EternalStorage {
         // Before store the contract we need to make sure that it is the block reward contract in actual fact,
         // call a specific method from the contract that should return a specific value
         bool isBlockRewardContract = false;
-        if (_blockReward.call(abi.encodeWithSignature("blockRewardContractId()"))) {
+        if (_blockReward.call(BLOCK_REWARD_CONTRACT_ID)) {
             isBlockRewardContract =
                 IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
-        } else if (_blockReward.call(abi.encodeWithSignature("bridgesAllowedLength()"))) {
+        } else if (_blockReward.call(BRIDGES_ALLOWED_LENGTH)) {
             isBlockRewardContract = IBlockReward(_blockReward).bridgesAllowedLength() != 0;
         }
         require(isBlockRewardContract);

--- a/contracts/upgradeable_contracts/BlockRewardFeeManager.sol
+++ b/contracts/upgradeable_contracts/BlockRewardFeeManager.sol
@@ -1,19 +1,15 @@
 pragma solidity 0.4.24;
 
 import "./BaseFeeManager.sol";
-import "../interfaces/IBlockReward.sol";
+import "./BlockRewardBridge.sol";
 
-contract BlockRewardFeeManager is BaseFeeManager {
+contract BlockRewardFeeManager is BaseFeeManager, BlockRewardBridge {
     function distributeFeeFromAffirmation(uint256 _fee) external {
         distributeFeeFromBlockReward(_fee);
     }
 
     function distributeFeeFromSignatures(uint256 _fee) external {
         distributeFeeFromBlockReward(_fee);
-    }
-
-    function _blockRewardContract() internal view returns (IBlockReward) {
-        return IBlockReward(addressStorage[keccak256(abi.encodePacked("blockRewardContract"))]);
     }
 
     /* solcov ignore next */

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -35,7 +35,7 @@ contract BridgeValidators is BaseBridgeValidators {
 
         setValidatorCount(_initialValidators.length);
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -34,7 +34,7 @@ contract BridgeValidators is BaseBridgeValidators {
         }
 
         setValidatorCount(_initialValidators.length);
-        uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
+        uintStorage[REQUIRED_SIGNATURES] = _requiredSignatures;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);

--- a/contracts/upgradeable_contracts/Claimable.sol
+++ b/contracts/upgradeable_contracts/Claimable.sol
@@ -4,6 +4,8 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "./Sacrifice.sol";
 
 contract Claimable {
+    bytes4 internal constant TRANSFER = 0xa9059cbb; // transfer(address,uint256)
+
     modifier validAddress(address _to) {
         require(_to != address(0));
         /* solcov ignore next */
@@ -34,7 +36,7 @@ contract Claimable {
     function safeTransfer(address _token, address _to, uint256 _value) internal {
         bytes memory returnData;
         bool returnDataResult;
-        bytes memory callData = abi.encodeWithSignature("transfer(address,uint256)", _to, _value);
+        bytes memory callData = abi.encodeWithSelector(TRANSFER, _to, _value);
         assembly {
             let result := call(gas, _token, 0x0, add(callData, 0x20), mload(callData), 0, 32)
             returnData := mload(0)

--- a/contracts/upgradeable_contracts/ERC20Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC20Bridge.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.4.24;
+
+import "../upgradeability/EternalStorage.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
+
+contract ERC20Bridge is EternalStorage {
+    bytes32 internal constant ERC20_TOKEN = keccak256(abi.encodePacked("erc20token"));
+
+    function erc20token() public view returns (ERC20Basic) {
+        return ERC20Basic(addressStorage[ERC20_TOKEN]);
+    }
+
+    function setErc20token(address _token) internal {
+        require(AddressUtils.isContract(_token));
+        addressStorage[ERC20_TOKEN] = _token;
+    }
+}

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -2,15 +2,16 @@ pragma solidity 0.4.24;
 
 import "./BasicBridge.sol";
 import "../interfaces/ERC677.sol";
+import "./ERC677Storage.sol";
 
-contract ERC677Bridge is BasicBridge {
+contract ERC677Bridge is BasicBridge, ERC677Storage {
     function erc677token() public view returns (ERC677) {
-        return ERC677(addressStorage[keccak256(abi.encodePacked("erc677token"))]);
+        return ERC677(addressStorage[ERC677_TOKEN]);
     }
 
     function setErc677token(address _token) internal {
         require(AddressUtils.isContract(_token));
-        addressStorage[keccak256(abi.encodePacked("erc677token"))] = _token;
+        addressStorage[ERC677_TOKEN] = _token;
     }
 
     function onTokenTransfer(

--- a/contracts/upgradeable_contracts/ERC677Storage.sol
+++ b/contracts/upgradeable_contracts/ERC677Storage.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.4.24;
+
+contract ERC677Storage {
+    bytes32 internal constant ERC677_TOKEN = keccak256(abi.encodePacked("erc677token"));
+}

--- a/contracts/upgradeable_contracts/Initializable.sol
+++ b/contracts/upgradeable_contracts/Initializable.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.4.24;
+
+import "../upgradeability/EternalStorage.sol";
+
+contract Initializable is EternalStorage {
+    bytes32 internal constant INITIALIZED = keccak256(abi.encodePacked("isInitialized"));
+    bytes32 internal constant DEPLOYED_AT_BLOCK = keccak256(abi.encodePacked("deployedAtBlock"));
+
+    function setInitialize() internal {
+        boolStorage[INITIALIZED] = true;
+    }
+
+    function isInitialized() public view returns (bool) {
+        return boolStorage[INITIALIZED];
+    }
+
+    function deployedAtBlock() external view returns (uint256) {
+        return uintStorage[DEPLOYED_AT_BLOCK];
+    }
+}

--- a/contracts/upgradeable_contracts/OverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/OverdrawManagement.sol
@@ -12,6 +12,8 @@ contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable, Ba
     event UserRequestForSignature(address recipient, uint256 value);
     event AssetAboveLimitsFixed(bytes32 indexed transactionHash, uint256 value, uint256 remaining);
 
+    bytes32 internal constant OUT_OF_LIMIT_AMOUNT = keccak256(abi.encodePacked("outOfLimitAmount"));
+
     function fixAssetsAboveLimits(bytes32 txHash, bool unlockOnForeign, uint256 valueToUnlock)
         external
         onlyIfUpgradeabilityOwner
@@ -41,7 +43,7 @@ contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable, Ba
     }
 
     function outOfLimitAmount() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))];
+        return uintStorage[OUT_OF_LIMIT_AMOUNT];
     }
 
     function fixedAssets(bytes32 _txHash) public view returns (bool) {
@@ -49,7 +51,7 @@ contract OverdrawManagement is EternalStorage, RewardableBridge, Upgradeable, Ba
     }
 
     function setOutOfLimitAmount(uint256 _value) internal {
-        uintStorage[keccak256(abi.encodePacked("outOfLimitAmount"))] = _value;
+        uintStorage[OUT_OF_LIMIT_AMOUNT] = _value;
     }
 
     function txAboveLimits(bytes32 _txHash) internal view returns (address recipient, uint256 value) {

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -8,6 +8,8 @@ contract RewardableBridge is Ownable, FeeTypes {
     event FeeDistributedFromAffirmation(uint256 feeAmount, bytes32 indexed transactionHash);
     event FeeDistributedFromSignatures(uint256 feeAmount, bytes32 indexed transactionHash);
 
+    bytes32 internal constant FEE_MANAGER_CONTRACT = keccak256(abi.encodePacked("feeManagerContract"));
+
     function _getFee(bytes32 _feeType) internal view returns (uint256) {
         uint256 fee;
         address feeManager = feeManagerContract();
@@ -43,12 +45,12 @@ contract RewardableBridge is Ownable, FeeTypes {
     }
 
     function feeManagerContract() public view returns (address) {
-        return addressStorage[keccak256(abi.encodePacked("feeManagerContract"))];
+        return addressStorage[FEE_MANAGER_CONTRACT];
     }
 
     function setFeeManagerContract(address _feeManager) external onlyOwner {
         require(_feeManager == address(0) || AddressUtils.isContract(_feeManager));
-        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
     }
 
     function _setFee(address _feeManager, uint256 _fee, bytes32 _feeType) internal {

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -40,7 +40,7 @@ contract RewardableValidators is BaseBridgeValidators {
 
         setValidatorCount(_initialValidators.length);
         uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);
 

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -39,7 +39,7 @@ contract RewardableValidators is BaseBridgeValidators {
         }
 
         setValidatorCount(_initialValidators.length);
-        uintStorage[keccak256(abi.encodePacked("requiredSignatures"))] = _requiredSignatures;
+        uintStorage[REQUIRED_SIGNATURES] = _requiredSignatures;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         setInitialize();
         emit RequiredSignaturesChanged(_requiredSignatures);

--- a/contracts/upgradeable_contracts/Validatable.sol
+++ b/contracts/upgradeable_contracts/Validatable.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.4.24;
+
 import "../interfaces/IBridgeValidators.sol";
 import "../upgradeability/EternalStorage.sol";
+import "./ValidatorStorage.sol";
 
-contract Validatable is EternalStorage {
-    bytes32 internal constant VALIDATOR_CONTRACT = keccak256(abi.encodePacked("validatorContract"));
-
+contract Validatable is EternalStorage, ValidatorStorage {
     function validatorContract() public view returns (IBridgeValidators) {
         return IBridgeValidators(addressStorage[VALIDATOR_CONTRACT]);
     }

--- a/contracts/upgradeable_contracts/Validatable.sol
+++ b/contracts/upgradeable_contracts/Validatable.sol
@@ -3,8 +3,10 @@ import "../interfaces/IBridgeValidators.sol";
 import "../upgradeability/EternalStorage.sol";
 
 contract Validatable is EternalStorage {
+    bytes32 internal constant VALIDATOR_CONTRACT = keccak256(abi.encodePacked("validatorContract"));
+
     function validatorContract() public view returns (IBridgeValidators) {
-        return IBridgeValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
+        return IBridgeValidators(addressStorage[VALIDATOR_CONTRACT]);
     }
 
     modifier onlyValidator() {

--- a/contracts/upgradeable_contracts/ValidatorStorage.sol
+++ b/contracts/upgradeable_contracts/ValidatorStorage.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.4.24;
+
+contract ValidatorStorage {
+    bytes32 internal constant VALIDATOR_CONTRACT = keccak256(abi.encodePacked("validatorContract"));
+}

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -21,7 +21,7 @@ contract ValidatorsFeeManager is BaseFeeManager {
     }
 
     function rewardableValidatorContract() internal view returns (IRewardableValidators) {
-        return IRewardableValidators(addressStorage[VALIDATOR_CONTRACT]);
+        return IRewardableValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
     }
 
     function distributeFeeProportionally(uint256 _fee, bytes32 _direction) internal {

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -21,7 +21,7 @@ contract ValidatorsFeeManager is BaseFeeManager {
     }
 
     function rewardableValidatorContract() internal view returns (IRewardableValidators) {
-        return IRewardableValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
+        return IRewardableValidators(addressStorage[VALIDATOR_CONTRACT]);
     }
 
     function distributeFeeProportionally(uint256 _fee, bytes32 _direction) internal {

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -2,8 +2,9 @@ pragma solidity 0.4.24;
 
 import "./BaseFeeManager.sol";
 import "../interfaces/IRewardableValidators.sol";
+import "./ValidatorStorage.sol";
 
-contract ValidatorsFeeManager is BaseFeeManager {
+contract ValidatorsFeeManager is BaseFeeManager, ValidatorStorage {
     bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_HOME = keccak256(
         abi.encodePacked("reward-transferring-from-home")
     );
@@ -21,7 +22,7 @@ contract ValidatorsFeeManager is BaseFeeManager {
     }
 
     function rewardableValidatorContract() internal view returns (IRewardableValidators) {
-        return IRewardableValidators(addressStorage[keccak256(abi.encodePacked("validatorContract"))]);
+        return IRewardableValidators(addressStorage[VALIDATOR_CONTRACT]);
     }
 
     function distributeFeeProportionally(uint256 _fee, bytes32 _direction) internal {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -25,7 +25,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -24,7 +24,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;
+        uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -22,7 +22,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc20token(_erc20token);
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -20,7 +20,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc20token(_erc20token);
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -27,7 +27,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
         setInitialize();
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -26,7 +26,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _homeDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
         setInitialize();

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -23,7 +23,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.4.24;
 
-import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
@@ -13,19 +12,7 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
     }
 
     function setBlockRewardContract(address _blockReward) external {
-        require(AddressUtils.isContract(_blockReward));
-
-        // Before store the contract we need to make sure that it is the block reward contract in actual fact,
-        // call a specific method from the contract that should return a specific value
-        bool isBlockRewardContract = false;
-        if (_blockReward.call(abi.encodeWithSignature("blockRewardContractId()"))) {
-            isBlockRewardContract =
-                IBlockReward(_blockReward).blockRewardContractId() == bytes4(keccak256("blockReward"));
-        } else if (_blockReward.call(abi.encodeWithSignature("bridgesAllowedLength()"))) {
-            isBlockRewardContract = IBlockReward(_blockReward).bridgesAllowedLength() != 0;
-        }
-        require(isBlockRewardContract);
-        addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
+        _setBlockRewardContract(_blockReward);
     }
 
     function distributeFeeFromBlockReward(uint256 _fee) internal {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -31,7 +31,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
             _owner
         );
 
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MIN_PER_TX] = _minPerTx;
 
         return isInitialized();

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -32,7 +32,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         );
 
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
 
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -1,8 +1,9 @@
 pragma solidity 0.4.24;
 
 import "./BasicForeignBridgeErcToErc.sol";
+import "../ERC20Bridge.sol";
 
-contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
+contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc, ERC20Bridge {
     function initialize(
         address _validatorContract,
         address _erc20token,
@@ -24,14 +25,5 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc {
             _owner
         );
         return isInitialized();
-    }
-
-    function erc20token() public view returns (ERC20Basic) {
-        return ERC20Basic(addressStorage[keccak256(abi.encodePacked("erc20token"))]);
-    }
-
-    function setErc20token(address _token) internal {
-        require(AddressUtils.isContract(_token));
-        addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -139,7 +139,7 @@ contract HomeBridgeErcToErc is
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
+        uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -140,7 +140,7 @@ contract HomeBridgeErcToErc is
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -142,7 +142,7 @@ contract HomeBridgeErcToErc is
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
         setErc677token(_erc677token);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -137,7 +137,7 @@ contract HomeBridgeErcToErc is
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -134,7 +134,7 @@ contract HomeBridgeErcToErc is
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -111,7 +111,7 @@ contract HomeBridgeErcToErc is
             _owner
         );
         require(AddressUtils.isContract(_feeManager));
-        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -141,7 +141,7 @@ contract HomeBridgeErcToErc is
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _foreignDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
         setErc677token(_erc677token);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -136,7 +136,7 @@ contract HomeBridgeErcToErc is
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -135,7 +135,7 @@ contract HomeBridgeErcToErc is
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -138,7 +138,7 @@ contract HomeBridgeErcToErc is
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -3,6 +3,9 @@ pragma solidity 0.4.24;
 import "./HomeBridgeErcToErc.sol";
 
 contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
+    bytes4 internal constant BLOCK_REWARD_CONTRACT_SELECTOR = 0x56b54bae; // blockRewardContract()
+    bytes4 internal constant SET_BLOCK_REWARD_CONTRACT = 0x27a3e16b; // setBlockRewardContract(address)
+
     function rewardableInitialize(
         address _validatorContract,
         uint256 _dailyLimit,
@@ -43,7 +46,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
     function blockRewardContract() public view returns (address) {
         address blockReward;
         address feeManager = feeManagerContract();
-        bytes memory callData = abi.encodeWithSignature("blockRewardContract()");
+        bytes memory callData = abi.encodeWithSelector(BLOCK_REWARD_CONTRACT_SELECTOR);
 
         assembly {
             let result := callcode(gas, feeManager, 0x0, add(callData, 0x20), mload(callData), 0, 32)
@@ -64,6 +67,6 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
     }
 
     function _setBlockRewardContract(address _feeManager, address _blockReward) internal {
-        require(_feeManager.delegatecall(abi.encodeWithSignature("setBlockRewardContract(address)", _blockReward)));
+        require(_feeManager.delegatecall(abi.encodeWithSelector(SET_BLOCK_REWARD_CONTRACT, _blockReward)));
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
@@ -3,18 +3,15 @@ pragma solidity 0.4.24;
 import "../../interfaces/IBlockReward.sol";
 import "../Sacrifice.sol";
 import "../ValidatorsFeeManager.sol";
+import "../BlockRewardBridge.sol";
 
-contract FeeManagerErcToNative is ValidatorsFeeManager {
+contract FeeManagerErcToNative is ValidatorsFeeManager, BlockRewardBridge {
     function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
     }
 
-    function blockRewardContract() internal view returns (IBlockReward) {
-        return IBlockReward(addressStorage[keccak256(abi.encodePacked("blockRewardContract"))]);
-    }
-
     function onAffirmationFeeDistribution(address _rewardAddress, uint256 _fee) internal {
-        IBlockReward blockReward = blockRewardContract();
+        IBlockReward blockReward = _blockRewardContract();
         blockReward.addExtraReceiver(_fee, _rewardAddress);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -31,7 +31,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
         setInitialize();
         return isInitialized();

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -27,7 +27,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -28,7 +28,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         setErc20token(_erc20token);
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _gasPrice;
+        uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -26,7 +26,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc20token(_erc20token);
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -1,11 +1,9 @@
 pragma solidity 0.4.24;
 
-import "../../libraries/Message.sol";
 import "../BasicForeignBridge.sol";
-import "../../interfaces/IBurnableMintableERC677Token.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "../ERC20Bridge.sol";
 
-contract ForeignBridgeErcToNative is BasicForeignBridge {
+contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
     event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
 
     function initialize(
@@ -46,10 +44,6 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         super.claimTokens(_token, _to);
     }
 
-    function erc20token() public view returns (ERC20Basic) {
-        return ERC20Basic(addressStorage[keccak256(abi.encodePacked("erc20token"))]);
-    }
-
     function onExecuteMessage(
         address _recipient,
         uint256 _amount,
@@ -57,11 +51,6 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
     ) internal returns (bool) {
         setTotalExecutedPerDay(getCurrentDay(), totalExecutedPerDay(getCurrentDay()).add(_amount));
         return erc20token().transfer(_recipient, _amount);
-    }
-
-    function setErc20token(address _token) private {
-        require(AddressUtils.isContract(_token));
-        addressStorage[keccak256(abi.encodePacked("erc20token"))] = _token;
     }
 
     function onFailedMessage(address, uint256, bytes32) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -24,7 +24,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc20token(_erc20token);
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -29,7 +29,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -30,7 +30,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge {
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
         uintStorage[MAX_PER_TX] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _homeDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
         setInitialize();

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -152,7 +152,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -154,7 +154,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
+        uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -158,7 +158,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -155,7 +155,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -149,7 +149,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         require(_blockReward == address(0) || AddressUtils.isContract(_blockReward));
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -94,7 +94,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
             _owner
         );
         require(AddressUtils.isContract(_feeManager));
-        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize();

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -153,7 +153,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -150,7 +150,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -18,6 +18,8 @@ contract HomeBridgeErcToNative is
 {
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
 
+    bytes32 internal constant TOTAL_BURNT_COINS = keccak256(abi.encodePacked("totalBurntCoins"));
+
     function() public payable {
         nativeTransfer();
     }
@@ -118,7 +120,7 @@ contract HomeBridgeErcToNative is
     }
 
     function totalBurntCoins() public view returns (uint256) {
-        return uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))];
+        return uintStorage[TOTAL_BURNT_COINS];
     }
 
     function setBlockRewardContract(address _blockReward) external onlyOwner {
@@ -187,7 +189,7 @@ contract HomeBridgeErcToNative is
     }
 
     function setTotalBurntCoins(uint256 _amount) internal {
-        uintStorage[keccak256(abi.encodePacked("totalBurntCoins"))] = _amount;
+        uintStorage[TOTAL_BURNT_COINS] = _amount;
     }
 
     function onFailedAffirmation(address _recipient, uint256 _value, bytes32 _txHash) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -151,7 +151,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -157,7 +157,7 @@ contract HomeBridgeErcToNative is EternalStorage, BasicHomeBridge, OverdrawManag
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         addressStorage[keccak256(abi.encodePacked("blockRewardContract"))] = _blockReward;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _foreignDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
     }

--- a/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
@@ -3,6 +3,8 @@ pragma solidity 0.4.24;
 import "../RewardableBridge.sol";
 
 contract RewardableHomeBridgeErcToNative is RewardableBridge {
+    bytes4 internal constant GET_AMOUNT_TO_BURN = 0x916850e9; // getAmountToBurn(uint256)
+
     function setHomeFee(uint256 _fee) external onlyOwner {
         _setFee(feeManagerContract(), _fee, HOME_FEE);
     }
@@ -21,7 +23,7 @@ contract RewardableHomeBridgeErcToNative is RewardableBridge {
 
     function getAmountToBurn(uint256 _value) public view returns (uint256) {
         uint256 amount;
-        bytes memory callData = abi.encodeWithSignature("getAmountToBurn(uint256)", _value);
+        bytes memory callData = abi.encodeWithSelector(GET_AMOUNT_TO_BURN, _value);
         address feeManager = feeManagerContract();
         assembly {
             let result := callcode(gas, feeManager, 0x0, add(callData, 0x20), mload(callData), 0, 32)

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
@@ -3,14 +3,15 @@ pragma solidity 0.4.24;
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "../Sacrifice.sol";
 import "../ValidatorsFeeManager.sol";
+import "../ERC677Storage.sol";
 
-contract FeeManagerNativeToErc is ValidatorsFeeManager {
+contract FeeManagerNativeToErc is ValidatorsFeeManager, ERC677Storage {
     function getFeeManagerMode() external pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
     }
 
     function erc677token() public view returns (IBurnableMintableERC677Token) {
-        return IBurnableMintableERC677Token(addressStorage[keccak256(abi.encodePacked("erc677token"))]);
+        return IBurnableMintableERC677Token(addressStorage[ERC677_TOKEN]);
     }
 
     function onAffirmationFeeDistribution(address _rewardAddress, uint256 _fee) internal {

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -104,7 +104,7 @@ contract ForeignBridgeNativeToErc is
         require(_foreignGasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc677token(_erc677token);
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -111,7 +111,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[GAS_PRICE] = _foreignGasPrice;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -112,7 +112,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _foreignGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _homeDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -109,7 +109,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _foreignGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -71,7 +71,7 @@ contract ForeignBridgeNativeToErc is
             _owner
         );
         require(AddressUtils.isContract(_feeManager));
-        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         setInitialize();
         return isInitialized();

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -108,7 +108,7 @@ contract ForeignBridgeNativeToErc is
         setErc677token(_erc677token);
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _foreignGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -113,7 +113,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[GAS_PRICE] = _foreignGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _homeMaxPerTx;
         setOwner(_owner);
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -106,7 +106,7 @@ contract ForeignBridgeNativeToErc is
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc677token(_erc677token);
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -107,7 +107,7 @@ contract ForeignBridgeNativeToErc is
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         setErc677token(_erc677token);
         uintStorage[DAILY_LIMIT] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _foreignGasPrice;

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -110,7 +110,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _foreignGasPrice;
+        uintStorage[GAS_PRICE] = _foreignGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _homeDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _homeMaxPerTx;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -107,7 +107,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
-        uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
+        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -113,7 +113,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
-        uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
+        uintStorage[EXECUTION_DAILY_LIMIT] = _foreignDailyLimit;
         uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
     }

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -111,7 +111,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
-        uintStorage[keccak256(abi.encodePacked("gasPrice"))] = _homeGasPrice;
+        uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -112,7 +112,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
         uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
-        uintStorage[keccak256(abi.encodePacked("requiredBlockConfirmations"))] = _requiredBlockConfirmations;
+        uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
         uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -109,7 +109,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
-        uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
+        uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -106,7 +106,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
-        addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
+        addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -114,7 +114,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;
-        uintStorage[keccak256(abi.encodePacked("executionMaxPerTx"))] = _foreignMaxPerTx;
+        uintStorage[EXECUTION_MAX_PER_TX] = _foreignMaxPerTx;
         setOwner(_owner);
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -110,7 +110,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
         uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
         uintStorage[keccak256(abi.encodePacked("maxPerTx"))] = _maxPerTx;
-        uintStorage[keccak256(abi.encodePacked("minPerTx"))] = _minPerTx;
+        uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[keccak256(abi.encodePacked("executionDailyLimit"))] = _foreignDailyLimit;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -108,7 +108,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         require(_owner != address(0));
         addressStorage[keccak256(abi.encodePacked("validatorContract"))] = _validatorContract;
         uintStorage[keccak256(abi.encodePacked("deployedAtBlock"))] = block.number;
-        uintStorage[keccak256(abi.encodePacked("dailyLimit"))] = _dailyLimit;
+        uintStorage[DAILY_LIMIT] = _dailyLimit;
         uintStorage[MAX_PER_TX] = _maxPerTx;
         uintStorage[MIN_PER_TX] = _minPerTx;
         uintStorage[GAS_PRICE] = _homeGasPrice;

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -77,7 +77,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
             _owner
         );
         require(AddressUtils.isContract(_feeManager));
-        addressStorage[keccak256(abi.encodePacked("feeManagerContract"))] = _feeManager;
+        addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
         _setFee(_feeManager, _homeFee, HOME_FEE);
         _setFee(_feeManager, _foreignFee, FOREIGN_FEE);
         setInitialize();


### PR DESCRIPTION
Moved mappings key to constant. This helps prevent issues caused by typos or erroneous copy-pastes, this also improves readability. Also some repeated code related to the constant was extracted to base contracts. I think the easiest way to review this PR is by reviewing commit per commit.