### PR TITLE
Enhance setStakingContract function

### DIFF
--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -17,6 +17,7 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
 
     function setStakingContract(address _stakingContract) external onlyOwner {
         require(AddressUtils.isContract(_stakingContract));
+        require(balanceOf(_stakingContract) == 0);
         stakingContract = _stakingContract;
     }
 

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -139,6 +139,17 @@ async function testERC677BridgeToken(accounts, rewardable) {
         await token.setStakingContract(ZERO_ADDRESS).should.be.rejectedWith(ERROR_MSG)
         ;(await token.stakingContract()).should.be.equal(ZERO_ADDRESS)
       })
+
+      it('fail to set Staking contract address with non-zero balance', async () => {
+        const stakingContract = await StakingTest.new()
+        ;(await token.stakingContract()).should.be.equal(ZERO_ADDRESS)
+
+        await token.mint(user, 1, { from: owner }).should.be.fulfilled
+        await token.transfer(stakingContract.address, 1, {from: user}).should.be.fulfilled
+
+        await token.setStakingContract(stakingContract.address).should.be.rejectedWith(ERROR_MSG)
+        ;(await token.stakingContract()).should.be.equal(ZERO_ADDRESS)
+      })
     })
 
     describe('#mintReward', async () => {

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -145,7 +145,7 @@ async function testERC677BridgeToken(accounts, rewardable) {
         ;(await token.stakingContract()).should.be.equal(ZERO_ADDRESS)
 
         await token.mint(user, 1, { from: owner }).should.be.fulfilled
-        await token.transfer(stakingContract.address, 1, {from: user}).should.be.fulfilled
+        await token.transfer(stakingContract.address, 1, { from: user }).should.be.fulfilled
 
         await token.setStakingContract(stakingContract.address).should.be.rejectedWith(ERROR_MSG)
         ;(await token.stakingContract()).should.be.equal(ZERO_ADDRESS)


### PR DESCRIPTION
This little change ensures that [`StakingAuRa`](https://github.com/poanetwork/posdao-contracts/blob/master/contracts/StakingAuRa.sol) contract has no tokens on its balance before its address is set to the `ERC677BridgeTokenRewardable.stakingContract` variable. The `StakingAuRa` contract must have zero balance when the network starts. The same checking was added to the `StakingAuRa.setErc20TokenContract` function: https://github.com/poanetwork/posdao-contracts/commit/2f3449b765494af346503a3de52f0fdfbe425eef#diff-d272eb6253b6a8415de90563f08ebb92