### PR TITLE
Add result information for AMB message call

### DIFF
--- a/contracts/interfaces/IAMB.sol
+++ b/contracts/interfaces/IAMB.sol
@@ -5,6 +5,8 @@ interface IAMB {
     function maxGasPerTx() external view returns (uint256);
     function transactionHash() external view returns (bytes32);
     function messageCallStatus(bytes32 _txHash) external view returns (address);
-    function messageDataHash(bytes32 _txHash) external view returns (bytes32);
+    function failedMessageDataHash(bytes32 _txHash) external view returns (bytes32);
+    function failedMessageReceiver(bytes32 _txHash) external view returns (address);
+    function failedMessageSender(bytes32 _txHash) external view returns (address);
     function requireToPassMessage(address _contract, bytes _data, uint256 _gas) external;
 }

--- a/contracts/interfaces/IAMB.sol
+++ b/contracts/interfaces/IAMB.sol
@@ -4,6 +4,7 @@ interface IAMB {
     function messageSender() external view returns (address);
     function maxGasPerTx() external view returns (uint256);
     function transactionHash() external view returns (bytes32);
-    function withdrawFromDeposit(address _recipient) external;
+    function messageCallStatus(bytes32 _txHash) external view returns (address);
+    function messageDataHash(bytes32 _txHash) external view returns (bytes32);
     function requireToPassMessage(address _contract, bytes _data, uint256 _gas) external;
 }

--- a/contracts/mocks/IAMB.sol
+++ b/contracts/mocks/IAMB.sol
@@ -1,8 +1,0 @@
-pragma solidity 0.4.24;
-
-interface IAMB {
-    function messageSender() external view returns (address);
-    function transactionHash() external view returns (bytes32);
-    function withdrawFromDeposit(address _recipient) external;
-    function requireToPassMessage(address _contract, bytes _data, uint256 _gas) public;
-}

--- a/contracts/upgradeable_contracts/arbitrary_message/ForeignAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/ForeignAMB.sol
@@ -4,7 +4,12 @@ import "./BasicForeignAMB.sol";
 
 contract ForeignAMB is BasicForeignAMB {
     event UserRequestForAffirmation(bytes encodedData);
-    event RelayedMessage(address sender, address executor, bytes32 transactionHash, bool status);
+    event RelayedMessage(
+        address indexed sender,
+        address indexed executor,
+        bytes32 indexed transactionHash,
+        bool status
+    );
 
     function emitEventOnMessageRequest(bytes encodedData) internal {
         emit UserRequestForAffirmation(encodedData);

--- a/contracts/upgradeable_contracts/arbitrary_message/HomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/HomeAMB.sol
@@ -4,7 +4,12 @@ import "./BasicHomeAMB.sol";
 
 contract HomeAMB is BasicHomeAMB {
     event UserRequestForSignature(bytes encodedData);
-    event AffirmationCompleted(address sender, address executor, bytes32 transactionHash, bool status);
+    event AffirmationCompleted(
+        address indexed sender,
+        address indexed executor,
+        bytes32 indexed transactionHash,
+        bool status
+    );
 
     function emitEventOnMessageRequest(bytes encodedData) internal {
         emit UserRequestForSignature(encodedData);

--- a/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
@@ -7,19 +7,35 @@ contract MessageProcessor is EternalStorage {
     bytes32 internal constant TRANSACTION_HASH = keccak256(abi.encodePacked("transactionHash"));
 
     function messageCallStatus(bytes32 _txHash) external view returns (bool) {
-        return boolStorage[keccak256(abi.encodePacked("callStatus", _txHash))];
+        return boolStorage[keccak256(abi.encodePacked("messageCallStatus", _txHash))];
     }
 
     function setMessageCallStatus(bytes32 _txHash, bool _status) internal {
-        boolStorage[keccak256(abi.encodePacked("callStatus", _txHash))] = _status;
+        boolStorage[keccak256(abi.encodePacked("messageCallStatus", _txHash))] = _status;
     }
 
-    function messageDataHash(bytes32 _txHash) external view returns (bytes32) {
-        return bytesToBytes32(bytesStorage[keccak256(abi.encodePacked("dataHash", _txHash))]);
+    function failedMessageDataHash(bytes32 _txHash) external view returns (bytes32) {
+        return bytesToBytes32(bytesStorage[keccak256(abi.encodePacked("failedMessageDataHash", _txHash))]);
     }
 
-    function setMessageDataHash(bytes32 _txHash, bytes data) internal {
-        bytesStorage[keccak256(abi.encodePacked("dataHash", _txHash))] = abi.encodePacked(keccak256(data));
+    function setFailedMessageDataHash(bytes32 _txHash, bytes data) internal {
+        bytesStorage[keccak256(abi.encodePacked("failedMessageDataHash", _txHash))] = abi.encodePacked(keccak256(data));
+    }
+
+    function failedMessageReceiver(bytes32 _txHash) external view returns (address) {
+        return addressStorage[keccak256(abi.encodePacked("failedMessageReceiver", _txHash))];
+    }
+
+    function setFailedMessageReceiver(bytes32 _txHash, address _receiver) internal {
+        addressStorage[keccak256(abi.encodePacked("failedMessageReceiver", _txHash))] = _receiver;
+    }
+
+    function failedMessageSender(bytes32 _txHash) external view returns (address) {
+        return addressStorage[keccak256(abi.encodePacked("failedMessageSender", _txHash))];
+    }
+
+    function setFailedMessageSender(bytes32 _txHash, address _sender) internal {
+        addressStorage[keccak256(abi.encodePacked("failedMessageSender", _txHash))] = _sender;
     }
 
     function messageSender() external view returns (address) {
@@ -57,7 +73,9 @@ contract MessageProcessor is EternalStorage {
 
         setMessageCallStatus(txHash, status);
         if (!status) {
-            setMessageDataHash(txHash, data);
+            setFailedMessageDataHash(txHash, data);
+            setFailedMessageReceiver(txHash, executor);
+            setFailedMessageSender(txHash, sender);
         }
         emitEventOnMessageProcessed(sender, executor, txHash, status);
     }

--- a/test/arbitrary_message/foreign_bridge.test.js
+++ b/test/arbitrary_message/foreign_bridge.test.js
@@ -429,7 +429,9 @@ contract('ForeignAMB', async accounts => {
       })
 
       expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
-      expect(await foreignBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await foreignBridge.failedMessageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await foreignBridge.failedMessageReceiver(resultPassMessageTx.tx)).to.be.equal(box.address)
+      expect(await foreignBridge.failedMessageSender(resultPassMessageTx.tx)).to.be.equal(user)
 
       await foreignBridge
         .executeSignatures(message, signatures, { from: authorities[0], gasPrice })
@@ -469,7 +471,9 @@ contract('ForeignAMB', async accounts => {
       })
 
       expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
-      expect(await foreignBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await foreignBridge.failedMessageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await foreignBridge.failedMessageReceiver(resultPassMessageTx.tx)).to.be.equal(box.address)
+      expect(await foreignBridge.failedMessageSender(resultPassMessageTx.tx)).to.be.equal(user)
 
       await foreignBridge
         .executeSignatures(message, signatures, { from: authorities[0], gasPrice })

--- a/test/arbitrary_message/foreign_bridge.test.js
+++ b/test/arbitrary_message/foreign_bridge.test.js
@@ -253,6 +253,8 @@ contract('ForeignAMB', async accounts => {
         status: true
       })
 
+      expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(true)
+
       // check Box value
       expect(await box.value()).to.be.bignumber.equal('3')
       expect(await box.lastSender()).to.be.equal(user)
@@ -393,11 +395,14 @@ contract('ForeignAMB', async accounts => {
         transactionHash: resultPassMessageTx.tx,
         status: true
       })
+
+      expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(true)
     })
     it('status of RelayedMessage should be false on contract failed call', async () => {
       const user = accounts[8]
 
       const methodWillFailData = box.contract.methods.methodWillFail().encodeABI()
+      const messageDataHash = web3.utils.soliditySha3(methodWillFailData)
 
       // Use these calls to simulate home bridge on home network
       const resultPassMessageTx = await foreignBridge.requireToPassMessage(box.address, methodWillFailData, 821254, {
@@ -423,6 +428,9 @@ contract('ForeignAMB', async accounts => {
         status: false
       })
 
+      expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
+      expect(await foreignBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+
       await foreignBridge
         .executeSignatures(message, signatures, { from: authorities[0], gasPrice })
         .should.be.rejectedWith(ERROR_MSG)
@@ -434,6 +442,7 @@ contract('ForeignAMB', async accounts => {
       const user = accounts[8]
 
       const methodOutOfGasData = box.contract.methods.methodOutOfGas().encodeABI()
+      const messageDataHash = web3.utils.soliditySha3(methodOutOfGasData)
 
       // Use these calls to simulate home bridge on home network
       const resultPassMessageTx = await foreignBridge.requireToPassMessage(box.address, methodOutOfGasData, 1000, {
@@ -458,6 +467,9 @@ contract('ForeignAMB', async accounts => {
         transactionHash: resultPassMessageTx.tx,
         status: false
       })
+
+      expect(await foreignBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
+      expect(await foreignBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
 
       await foreignBridge
         .executeSignatures(message, signatures, { from: authorities[0], gasPrice })

--- a/test/arbitrary_message/home_bridge.test.js
+++ b/test/arbitrary_message/home_bridge.test.js
@@ -270,6 +270,8 @@ contract('HomeAMB', async accounts => {
         status: true
       })
 
+      expect(await homeBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(true)
+
       // check Box value
       expect(await box.value()).to.be.bignumber.equal('3')
       expect(await box.lastSender()).to.be.equal(user)
@@ -412,6 +414,7 @@ contract('HomeAMB', async accounts => {
       const user = accounts[8]
 
       const methodWillFailData = box.contract.methods.methodWillFail().encodeABI()
+      const messageDataHash = web3.utils.soliditySha3(methodWillFailData)
 
       // Use these calls to simulate foreign bridge on Foreign network
       const resultPassMessageTx = await homeBridge.requireToPassMessage(box.address, methodWillFailData, 141647, {
@@ -432,6 +435,9 @@ contract('HomeAMB', async accounts => {
         status: false
       })
 
+      expect(await homeBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
+      expect(await homeBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+
       await homeBridge.executeAffirmation(message, { from: authorities[0], gasPrice }).should.be.rejectedWith(ERROR_MSG)
       await homeBridge.executeAffirmation(message, { from: authorities[1], gasPrice }).should.be.rejectedWith(ERROR_MSG)
     })
@@ -439,6 +445,7 @@ contract('HomeAMB', async accounts => {
       const user = accounts[8]
 
       const methodOutOfGasData = box.contract.methods.methodOutOfGas().encodeABI()
+      const messageDataHash = web3.utils.soliditySha3(methodOutOfGasData)
 
       // Use these calls to simulate foreign bridge on Foreign network
       const resultPassMessageTx = await homeBridge.requireToPassMessage(box.address, methodOutOfGasData, 1000, {
@@ -458,6 +465,9 @@ contract('HomeAMB', async accounts => {
         transactionHash: resultPassMessageTx.tx,
         status: false
       })
+
+      expect(await homeBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
+      expect(await homeBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
 
       await homeBridge.executeAffirmation(message, { from: authorities[0], gasPrice }).should.be.rejectedWith(ERROR_MSG)
       await homeBridge.executeAffirmation(message, { from: authorities[1], gasPrice }).should.be.rejectedWith(ERROR_MSG)

--- a/test/arbitrary_message/home_bridge.test.js
+++ b/test/arbitrary_message/home_bridge.test.js
@@ -436,7 +436,9 @@ contract('HomeAMB', async accounts => {
       })
 
       expect(await homeBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
-      expect(await homeBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await homeBridge.failedMessageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await homeBridge.failedMessageReceiver(resultPassMessageTx.tx)).to.be.equal(box.address)
+      expect(await homeBridge.failedMessageSender(resultPassMessageTx.tx)).to.be.equal(user)
 
       await homeBridge.executeAffirmation(message, { from: authorities[0], gasPrice }).should.be.rejectedWith(ERROR_MSG)
       await homeBridge.executeAffirmation(message, { from: authorities[1], gasPrice }).should.be.rejectedWith(ERROR_MSG)
@@ -467,7 +469,9 @@ contract('HomeAMB', async accounts => {
       })
 
       expect(await homeBridge.messageCallStatus(resultPassMessageTx.tx)).to.be.equal(false)
-      expect(await homeBridge.messageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await homeBridge.failedMessageDataHash(resultPassMessageTx.tx)).to.be.equal(messageDataHash)
+      expect(await homeBridge.failedMessageReceiver(resultPassMessageTx.tx)).to.be.equal(box.address)
+      expect(await homeBridge.failedMessageSender(resultPassMessageTx.tx)).to.be.equal(user)
 
       await homeBridge.executeAffirmation(message, { from: authorities[0], gasPrice }).should.be.rejectedWith(ERROR_MSG)
       await homeBridge.executeAffirmation(message, { from: authorities[1], gasPrice }).should.be.rejectedWith(ERROR_MSG)


### PR DESCRIPTION
Closes #281 

Implemented the approach mentioned in [this comment](https://github.com/poanetwork/poa-bridge-contracts/issues/281#issuecomment-529516782).

Also added `indexed` property to parameters of AMB events. This could be useful for filtering events from/to a specific mediator or by transaction hash.