### PR TITLE
Fix setTotalSpentPerDay called twice in AMB-ERC-TO-ERC

### DIFF
--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -108,6 +108,17 @@ contract BasicAMBErc677ToErc677 is
         _relayTokens(msg.sender, _receiver, _value);
     }
 
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns (bool) {
+        ERC677 token = erc677token();
+        require(msg.sender == address(token));
+        if (!lock()) {
+            require(withinLimit(_value));
+            setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_value));
+        }
+        bridgeSpecificActionsOnTokenTransfer(token, _from, _value, _data);
+        return true;
+    }
+
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (1, 0, 0);
     }

--- a/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
+++ b/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
@@ -521,6 +521,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -531,6 +534,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow user to specify a itself as receiver', async () => {
       // Given
@@ -545,6 +549,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -557,6 +564,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to specify a different receiver', async () => {
       // Given
@@ -571,6 +579,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -583,6 +594,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to specify a different receiver without specifying sender', async () => {
       // Given
@@ -597,6 +609,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -608,6 +623,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to complete a transfer approved by other user', async () => {
       // Given
@@ -621,6 +637,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         decimalShiftZero,
         owner
       ).should.be.fulfilled
+
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
 
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
@@ -637,6 +656,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should fail if user did not approve the transfer', async () => {
       await contract.initialize(
@@ -690,6 +710,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc677Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -700,6 +723,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should prevent emitting the event twice when ERC677 used by relayTokens and ERC677 is not owned by token manager', async function() {
       // Given
@@ -719,6 +743,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc677Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -729,6 +756,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
   })
   describe('requestFailedMessageFix', () => {


### PR DESCRIPTION
This PR fixes a bug that causes `setTotalSpentPerDay` to be called twice when an erc677 invokes `relayTokens` in `AMB-ERC-TO-ERC` mode.

With this fix `totalSpentPerDay` is correctly updated for the following scenarios:
- ERC20 calling `relayTokens`
- ERC677 calling `relayTokens`
- ERC677 calling `transferAndCall` direclty